### PR TITLE
Changed script execution order and added web request exception handling.

### DIFF
--- a/Assets/GLTF/Examples/WebServerComponent.cs.meta
+++ b/Assets/GLTF/Examples/WebServerComponent.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: 0be99a1796ece0b4581c1fde52a1e4df
-timeCreated: 1493411889
-licenseType: Pro
+timeCreated: 1504893105
+licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 100
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/GLTF/Scripts/Exceptions.cs
+++ b/Assets/GLTF/Scripts/Exceptions.cs
@@ -1,7 +1,21 @@
 using System;
+using UnityEngine.Networking;
 
 namespace GLTF
 {
+	[Serializable()]
+	public class WebRequestException : Exception
+	{
+		public WebRequestException() : base() { }
+		public WebRequestException(string message) : base(message) { }
+		public WebRequestException(string message, Exception inner) : base(message, inner) { }
+		public WebRequestException(UnityWebRequest www) : base(string.Format("Error: {0} when requesting: {1}", www.responseCode, www.url)) { }
+
+		protected WebRequestException(System.Runtime.Serialization.SerializationInfo info,
+			System.Runtime.Serialization.StreamingContext context)
+		{ }
+	}
+
 	[Serializable()]
 	public class GLTFHeaderInvalidException : Exception
 	{

--- a/Assets/GLTF/Scripts/GLTFComponent.cs.meta
+++ b/Assets/GLTF/Scripts/GLTFComponent.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: 3628db10e32278e499da95887f1bc989
-timeCreated: 1488842155
+timeCreated: 1504893105
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 200
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/GLTF/Scripts/GLTFLoader.cs
+++ b/Assets/GLTF/Scripts/GLTFLoader.cs
@@ -58,13 +58,12 @@ namespace GLTF
 				var www = UnityWebRequest.Get(_gltfUrl);
 
 				yield return www.Send();
-				if (www.responseCode >= 400)
+				if (www.responseCode >= 400 || www.responseCode == 0)
 				{
-					Debug.LogErrorFormat("{0} - {1}", www.responseCode, www.url);
-					yield break;
+					throw new WebRequestException(www);
 				}
 
-				var gltfData = www.downloadHandler.data;
+                var gltfData = www.downloadHandler.data;
 
 				if (Multithreaded)
 				{

--- a/Assets/GLTF/Scripts/GLTFParser.cs
+++ b/Assets/GLTF/Scripts/GLTFParser.cs
@@ -20,6 +20,11 @@ namespace GLTF
 			string gltfContent;
 			glbBuffer = null;
 
+			if (gltfBinary.Length == 0)
+			{
+				throw new GLTFHeaderInvalidException("glTF file cannot be empty.");
+			}
+
 			// Check for binary format magic bytes
 			if (BitConverter.ToUInt32(gltfBinary, 0) == 0x46546c67)
 			{


### PR DESCRIPTION
Fixes #45 

Script execution order of GLTFComponent and WebServerComponent was different on macOS. I added an explicit script execution order for these components and additional exception handling so these types of errors are easier to spot in the future.