### PR TITLE
Fix a bug in AbsoluteUriPath function not working properly if the uri has a query part ( also include a fix for Unity 2017 )

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -728,7 +728,7 @@ namespace UnityGLTF
 		protected static string AbsoluteUriPath(string gltfPath)
 		{
 			var uri = new Uri(gltfPath);
-			var partialPath = uri.AbsoluteUri.Remove(uri.AbsoluteUri.Length - uri.Segments[uri.Segments.Length - 1].Length);
+			var partialPath = uri.AbsoluteUri.Remove(uri.AbsoluteUri.Length - uri.Query.Length - uri.Segments[uri.Segments.Length - 1].Length);
 			return partialPath;
 		}
 

--- a/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/Batch.cs
+++ b/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/Batch.cs
@@ -68,13 +68,14 @@ namespace UnityTest
 				port = port
 			};
 
+#if !UNITY_2017
 			if (Application.isWebPlayer)
 			{
 				config.sendResultsOverNetwork = false;
 				Debug.Log("You can't use WebPlayer as active platform for running integration tests. Switching to Standalone");
 				EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTarget.StandaloneWindows);
 			}
-
+#endif
 			PlatformRunner.BuildAndRunInPlayer(config);
 		}
 


### PR DESCRIPTION
- Fix a bug in AbsoluteUriPath function not working properly if the uri has a query part
- Change Batch.cs to work with Unity 2017 ( because of the deprecated isWebPlayer)