### PR TITLE
Fix for 2017.2

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Shaders/GLTFStandardInput.cginc
+++ b/UnityGLTF/Assets/UnityGLTF/Shaders/GLTFStandardInput.cginc
@@ -154,7 +154,6 @@ half4 SpecularGloss(float2 uv)
 	return sg;
 }
 
-#ifdef UNITY_2017
 half2 MetallicRough(float2 uv)
 {
 	half2 mr;
@@ -165,7 +164,7 @@ half2 MetallicRough(float2 uv)
 
 	return mr;
 }
-#endif
+
 
 half2 MetallicGloss(float2 uv)
 {

--- a/UnityGLTF/Assets/UnityGLTF/Shaders/GLTFStandardInput.cginc
+++ b/UnityGLTF/Assets/UnityGLTF/Shaders/GLTFStandardInput.cginc
@@ -154,6 +154,17 @@ half4 SpecularGloss(float2 uv)
 	return sg;
 }
 
+half2 MetallicRough(float2 uv)
+{
+	half2 mg;
+
+	fixed4 mr = tex2D(_MetallicRoughnessMap, uv);
+	mg.x = mr.b * _Metallic;
+	mg.y = 1 - (mr.g * _Roughness);
+
+	return mg;
+}
+
 half2 MetallicGloss(float2 uv)
 {
 	half2 mg;

--- a/UnityGLTF/Assets/UnityGLTF/Shaders/GLTFStandardInput.cginc
+++ b/UnityGLTF/Assets/UnityGLTF/Shaders/GLTFStandardInput.cginc
@@ -154,16 +154,18 @@ half4 SpecularGloss(float2 uv)
 	return sg;
 }
 
+#ifdef UNITY_2017
 half2 MetallicRough(float2 uv)
 {
-	half2 mg;
+	half2 mr;
 
-	fixed4 mr = tex2D(_MetallicRoughnessMap, uv);
-	mg.x = mr.b * _Metallic;
-	mg.y = 1 - (mr.g * _Roughness);
+	fixed4 mrmap = tex2D(_MetallicRoughnessMap, uv);
+	mr.x = mrmap.b * _Metallic;
+	mr.y = mrmap.g * _Roughness;
 
-	return mg;
+	return mr;
 }
+#endif
 
 half2 MetallicGloss(float2 uv)
 {
@@ -175,6 +177,7 @@ half2 MetallicGloss(float2 uv)
 
 	return mg;
 }
+
 
 half3 Emission(float2 uv)
 {


### PR DESCRIPTION
Potentially fixes #58 by adding  metallicRough to glTFStandardinput.
Disclaimer: I have no idea why this works but it did with 2017.2 :).

I haven't tested this in 5.6 and not sure if an ifdef needs to be added? 