### PR TITLE
Check for spec gloss per material

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -503,7 +503,7 @@ namespace UnityGLTF
 					material.SetFloat("_Roughness", (float) pbr.RoughnessFactor);
 				}
 				
-				if (_root.ExtensionsUsed != null && _root.ExtensionsUsed.Contains(KHR_materials_pbrSpecularGlossinessExtensionFactory.EXTENSION_NAME))
+				if (def.Extensions.ContainsKey(KHR_materials_pbrSpecularGlossinessExtensionFactory.EXTENSION_NAME))
 				{
 					KHR_materials_pbrSpecularGlossinessExtension specGloss = def.Extensions[KHR_materials_pbrSpecularGlossinessExtensionFactory.EXTENSION_NAME] as KHR_materials_pbrSpecularGlossinessExtension;
 					


### PR DESCRIPTION
Perfectly possible to have extensionsUsed Spec Gloss and have one material in the file that doesn't use it. So the importer should check to see if spec gloss extension is defined per material rather than relying on extensionUsed property.
