### PR TITLE
Flip vertical compontent of UVs instead of negating them

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Schema/Accessor.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/Accessor.cs
@@ -501,7 +501,7 @@ namespace GLTF.Schema
 			var arr = AsVector2Array(ref contents, bufferData);
 			for (var i = 0; i < arr.Length; i++)
 			{
-				arr[i].Y *= -1;
+				arr[i].Y = 1 - arr[i].Y;
 			}
 
 			contents.AsTexcoords = arr;

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -310,10 +310,10 @@ namespace UnityGLTF
 				aTangent = ExportAccessor(InvertW(meshObj.tangents));
 
 			if (meshObj.uv.Length != 0)
-				aTexcoord0 = ExportAccessor(InvertY(meshObj.uv));
+				aTexcoord0 = ExportAccessor(FlipY(meshObj.uv));
 
 			if (meshObj.uv2.Length != 0)
-				aTexcoord1 = ExportAccessor(InvertY(meshObj.uv2));
+				aTexcoord1 = ExportAccessor(FlipY(meshObj.uv2));
 
 			if (meshObj.colors.Length != 0)
 				aColor0 = ExportAccessor(meshObj.colors);
@@ -726,12 +726,12 @@ namespace UnityGLTF
 			return samplerId;
 		}
 
-		private Vector2[] InvertY(Vector2[] arr)
+		private Vector2[] FlipY(Vector2[] arr)
 		{
 			var len = arr.Length;
 			for(var i = 0; i < len; i++)
 			{
-				arr[i].y = -arr[i].y;
+				arr[i].y = 1 - arr[i].y;
 			}
 			return arr;
 		}


### PR DESCRIPTION
Adjustment to how UV.Y is flipped so that clamp warp modes are supported.  See issue https://github.com/KhronosGroup/UnityGLTF/issues/101