### PR TITLE
Compute stream length relative to position

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -112,7 +112,7 @@ namespace UnityGLTF
 			else if (_loadType == LoadType.Stream)
 			{
 				// todo optimization: add stream support to parsing layer
-				int streamLength = (int) _gltfStream.Length;
+				int streamLength = (int)(_gltfStream.Length - _gltfStream.Position);
 				_gltfData = new byte[streamLength];
 				_gltfStream.Read(_gltfData, 0, streamLength);
 			}


### PR DESCRIPTION
I'm working on a 3D Tiles renderer for unity.  The 3D Tiles spec wraps glb files in [b3dm](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/TileFormats/Batched3DModel) format which is basically just a glb file with some additional header information.  

When GLTFSceneImporter.Load is called it currently uses the entire length of the input stream, which means I need to create an extra memory stream and copy the glb data into it for load to work.  It's desirable to just scrub past the header and then pass in the original stream.  This can be supported by measuring the remaining stream length relative to the streams current position.  This should be fine since the glb element is always the last thing in the b3dm file.

Cheers