### PR TITLE
Move coordinate space conversion into the UnityGLTF layer

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Schema/Accessor.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/Accessor.cs
@@ -501,77 +501,45 @@ namespace GLTF.Schema
 		{
 			if (contents.AsTexcoords != null) return contents.AsTexcoords;
 
-			var arr = AsVector2Array(ref contents, bufferViewData, offset);
-			for (var i = 0; i < arr.Length; i++)
-			{
-				arr[i].Y = 1 - arr[i].Y;
-			}
+			contents.AsTexcoords = AsVector2Array(ref contents, bufferViewData, offset);
 
-			contents.AsTexcoords = arr;
-
-			return arr;
+			return contents.AsTexcoords;
 		}
 
 		public Vector3[] AsVertexArray(ref NumericArray contents, byte[] bufferViewData, int offset)
 		{
 			if (contents.AsVertices != null) return contents.AsVertices;
 
-			var arr = AsVector3Array(ref contents, bufferViewData, offset);
-			for (var i = 0; i < arr.Length; i++)
-			{
-				arr[i].Z *= -1;
-			}
+			contents.AsVertices = AsVector3Array(ref contents, bufferViewData, offset);
 
-			contents.AsVertices = arr;
-
-			return arr;
+			return contents.AsVertices;
 		}
 
 		public Vector3[] AsNormalArray(ref NumericArray contents, byte[] bufferViewData, int offset)
 		{
 			if (contents.AsNormals != null) return contents.AsNormals;
 
-			var arr = AsVector3Array(ref contents, bufferViewData, offset);
-			for (var i = 0; i < arr.Length; i++)
-			{
-				arr[i].Z *= -1;
-			}
+			contents.AsNormals = AsVector3Array(ref contents, bufferViewData, offset);
 
-			contents.AsNormals = arr;
-
-			return arr;
+			return contents.AsNormals;
 		}
 
 		public Vector4[] AsTangentArray(ref NumericArray contents, byte[] bufferViewData, int offset)
 		{
 			if (contents.AsTangents != null) return contents.AsTangents;
 
-			var arr = AsVector4Array(ref contents, bufferViewData, offset);
-			for (var i = 0; i < arr.Length; i++)
-			{
-				arr[i].W *= -1;
-			}
+			contents.AsTangents = AsVector4Array(ref contents, bufferViewData, offset);
 
-			contents.AsTangents = arr;
-
-			return arr;
+			return contents.AsTangents;
 		}
 
 		public uint[] AsTriangles(ref NumericArray contents, byte[] bufferViewData, int offset)
 		{
 			if (contents.AsTriangles != null) return contents.AsTriangles;
 
-			var arr = AsUIntArray(ref contents, bufferViewData, offset);
-			for (var i = 0; i < arr.Length; i += 3)
-			{
-				var temp = arr[i];
-				arr[i] = arr[i + 2];
-				arr[i + 2] = temp;
-			}
+			contents.AsTriangles = AsUIntArray(ref contents, bufferViewData, offset);
 
-			contents.AsTriangles = arr;
-
-			return arr;
+			return contents.AsTriangles;
 		}
 
 		private static int GetDiscreteElement(byte[] bufferViewData, int offset, GLTFComponentType type)

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -28,7 +28,7 @@ namespace UnityGLTF
 			FileStream gltfStream = null;
 			if (UseStream)
 			{
-				var fullPath = Application.streamingAssetsPath + Url;
+				var fullPath = Path.Combine(Application.streamingAssetsPath, Url);
 				gltfStream = File.OpenRead(fullPath);
 				loader = new GLTFSceneImporter(
 					fullPath,

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -312,10 +312,10 @@ namespace UnityGLTF
 				aTangent = ExportAccessor(GLTFUnityHelpers.FlipVectorArrayHandedness(meshObj.tangents));
 
 			if (meshObj.uv.Length != 0)
-				aTexcoord0 = ExportAccessor(GLTFUnityHelpers.FlipTexCoordArrayY(meshObj.uv));
+				aTexcoord0 = ExportAccessor(GLTFUnityHelpers.FlipTexCoordArrayV(meshObj.uv));
 
 			if (meshObj.uv2.Length != 0)
-				aTexcoord1 = ExportAccessor(GLTFUnityHelpers.FlipTexCoordArrayY(meshObj.uv2));
+				aTexcoord1 = ExportAccessor(GLTFUnityHelpers.FlipTexCoordArrayV(meshObj.uv2));
 
 			if (meshObj.colors.Length != 0)
 				aColor0 = ExportAccessor(meshObj.colors);

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -303,19 +303,19 @@ namespace UnityGLTF
 			AccessorId aPosition = null, aNormal = null, aTangent = null,
 				aTexcoord0 = null, aTexcoord1 = null, aColor0 = null;
 
-			aPosition = ExportAccessor(InvertZ(meshObj.vertices));
+			aPosition = ExportAccessor(GLTFUnityHelpers.FlipVectorArrayHandedness(meshObj.vertices));
 
 			if (meshObj.normals.Length != 0)
-				aNormal = ExportAccessor(InvertZ(meshObj.normals));
+				aNormal = ExportAccessor(GLTFUnityHelpers.FlipVectorArrayHandedness(meshObj.normals));
 
 			if (meshObj.tangents.Length != 0)
-				aTangent = ExportAccessor(InvertW(meshObj.tangents));
+				aTangent = ExportAccessor(GLTFUnityHelpers.FlipVectorArrayHandedness(meshObj.tangents));
 
 			if (meshObj.uv.Length != 0)
-				aTexcoord0 = ExportAccessor(FlipY(meshObj.uv));
+				aTexcoord0 = ExportAccessor(GLTFUnityHelpers.FlipTexCoordArrayY(meshObj.uv));
 
 			if (meshObj.uv2.Length != 0)
-				aTexcoord1 = ExportAccessor(FlipY(meshObj.uv2));
+				aTexcoord1 = ExportAccessor(GLTFUnityHelpers.FlipTexCoordArrayY(meshObj.uv2));
 
 			if (meshObj.colors.Length != 0)
 				aColor0 = ExportAccessor(meshObj.colors);
@@ -327,7 +327,7 @@ namespace UnityGLTF
 				var primitive = new MeshPrimitive();
 				
 				var triangles = meshObj.GetTriangles(submesh);
-				primitive.Indices = ExportAccessor(FlipFaces(triangles), true);
+				primitive.Indices = ExportAccessor(GLTFUnityHelpers.FlipFaces(triangles), true);
 
 				primitive.Attributes = new Dictionary<string, AccessorId>();
 				primitive.Attributes.Add(SemanticProperties.POSITION, aPosition);
@@ -726,48 +726,6 @@ namespace UnityGLTF
 			_root.Samplers.Add(sampler);
 
 			return samplerId;
-		}
-
-		private Vector2[] FlipY(Vector2[] arr)
-		{
-			var len = arr.Length;
-			for(var i = 0; i < len; i++)
-			{
-				arr[i].y = 1 - arr[i].y;
-			}
-			return arr;
-		}
-
-		private Vector3[] InvertZ(Vector3[] arr)
-		{
-			var len = arr.Length;
-			for(var i = 0; i < len; i++)
-			{
-				arr[i].z = -arr[i].z;
-			}
-			return arr;
-		}
-
-		private Vector4[] InvertW(Vector4[] arr)
-		{
-			var len = arr.Length;
-			for(var i = 0; i < len; i++)
-			{
-				arr[i].w = -arr[i].w;
-			}
-			return arr;
-		}
-
-		private int[] FlipFaces(int[] arr)
-		{
-			var triangles = new int[arr.Length];
-			for (int i = 0; i < arr.Length; i += 3)
-			{
-				triangles[i + 2] = arr[i];
-				triangles[i + 1] = arr[i + 1];
-				triangles[i] = arr[i + 2];
-			}
-			return triangles;
 		}
 
 		private AccessorId ExportAccessor(int[] arr, bool isIndices = false)

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -257,6 +257,38 @@ namespace UnityGLTF
 				}
 
 				GLTFHelpers.BuildMeshAttributes(ref attributeAccessors);
+
+				// Flip vectors and triangles to the Unity coordinate system.
+				if (attributeAccessors.ContainsKey(SemanticProperties.POSITION))
+				{
+					NumericArray resultArray = attributeAccessors[SemanticProperties.POSITION].AccessorContent;
+					GLTFUnityHelpers.FlipVectorArrayHandedness(resultArray.AsVertices);
+				}
+				if (attributeAccessors.ContainsKey(SemanticProperties.INDICES))
+				{
+					NumericArray resultArray = attributeAccessors[SemanticProperties.INDICES].AccessorContent;
+					GLTFUnityHelpers.FlipFaces(resultArray.AsTriangles);
+				}
+				if (attributeAccessors.ContainsKey(SemanticProperties.NORMAL))
+				{
+					NumericArray resultArray = attributeAccessors[SemanticProperties.NORMAL].AccessorContent;
+					GLTFUnityHelpers.FlipVectorArrayHandedness(resultArray.AsNormals);
+				}
+				// TexCoord goes from 0 to 3 to match GLTFHelpers.BuildMeshAttributes
+				for (int i = 0; i < 4; i++)
+				{
+					if (attributeAccessors.ContainsKey(SemanticProperties.TexCoord(i)))
+					{
+						NumericArray resultArray = attributeAccessors[SemanticProperties.TexCoord(i)].AccessorContent;
+						GLTFUnityHelpers.FlipTexCoordArrayY(resultArray.AsTexcoords);
+					}
+				}
+				if (attributeAccessors.ContainsKey(SemanticProperties.TANGENT))
+				{
+					NumericArray resultArray = attributeAccessors[SemanticProperties.TANGENT].AccessorContent;
+					GLTFUnityHelpers.FlipVectorArrayHandedness(resultArray.AsTangents);
+				}
+
 				_assetCache.MeshCache[meshID][primitiveIndex].MeshAttributes = attributeAccessors;
 			}
 		}

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -262,17 +262,20 @@ namespace UnityGLTF
 				if (attributeAccessors.ContainsKey(SemanticProperties.POSITION))
 				{
 					NumericArray resultArray = attributeAccessors[SemanticProperties.POSITION].AccessorContent;
-					GLTFUnityHelpers.FlipVectorArrayHandedness(resultArray.AsVertices);
+					resultArray.AsVertices = GLTFUnityHelpers.FlipVectorArrayHandedness(resultArray.AsVertices);
+					attributeAccessors[SemanticProperties.POSITION].AccessorContent = resultArray;
 				}
 				if (attributeAccessors.ContainsKey(SemanticProperties.INDICES))
 				{
 					NumericArray resultArray = attributeAccessors[SemanticProperties.INDICES].AccessorContent;
-					GLTFUnityHelpers.FlipFaces(resultArray.AsTriangles);
+					resultArray.AsTriangles = GLTFUnityHelpers.FlipFaces(resultArray.AsTriangles);
+					attributeAccessors[SemanticProperties.INDICES].AccessorContent = resultArray;
 				}
 				if (attributeAccessors.ContainsKey(SemanticProperties.NORMAL))
 				{
 					NumericArray resultArray = attributeAccessors[SemanticProperties.NORMAL].AccessorContent;
-					GLTFUnityHelpers.FlipVectorArrayHandedness(resultArray.AsNormals);
+					resultArray.AsNormals = GLTFUnityHelpers.FlipVectorArrayHandedness(resultArray.AsNormals);
+					attributeAccessors[SemanticProperties.NORMAL].AccessorContent = resultArray;
 				}
 				// TexCoord goes from 0 to 3 to match GLTFHelpers.BuildMeshAttributes
 				for (int i = 0; i < 4; i++)
@@ -280,13 +283,15 @@ namespace UnityGLTF
 					if (attributeAccessors.ContainsKey(SemanticProperties.TexCoord(i)))
 					{
 						NumericArray resultArray = attributeAccessors[SemanticProperties.TexCoord(i)].AccessorContent;
-						GLTFUnityHelpers.FlipTexCoordArrayY(resultArray.AsTexcoords);
+						resultArray.AsTexcoords = GLTFUnityHelpers.FlipTexCoordArrayV(resultArray.AsTexcoords);
+						attributeAccessors[SemanticProperties.TexCoord(i)].AccessorContent = resultArray;
 					}
 				}
 				if (attributeAccessors.ContainsKey(SemanticProperties.TANGENT))
 				{
 					NumericArray resultArray = attributeAccessors[SemanticProperties.TANGENT].AccessorContent;
-					GLTFUnityHelpers.FlipVectorArrayHandedness(resultArray.AsTangents);
+					resultArray.AsTangents = GLTFUnityHelpers.FlipVectorArrayHandedness(resultArray.AsTangents);
+					attributeAccessors[SemanticProperties.TANGENT].AccessorContent = resultArray;
 				}
 
 				_assetCache.MeshCache[meshID][primitiveIndex].MeshAttributes = attributeAccessors;

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFUnityHelpers.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFUnityHelpers.cs
@@ -1,0 +1,127 @@
+﻿using UnityEngine;
+
+namespace UnityGLTF
+{
+    public static class GLTFUnityHelpers
+    {
+        public static Vector2 FlipTexCoordY(Vector2 vector2)
+        {
+            vector2.y = 1 - vector2.y;
+            return vector2;
+        }
+
+        public static GLTF.Math.Vector2 FlipTexCoordY(GLTF.Math.Vector2 vector2)
+        {
+            vector2.Y = 1 - vector2.Y;
+            return vector2;
+        }
+
+        public static Vector2[] FlipTexCoordArrayY(Vector2[] arr)
+        {
+            for (var i = 0; i < arr.Length; i++)
+            {
+                arr[i] = FlipTexCoordY(arr[i]);
+            }
+            return arr;
+        }
+
+        public static GLTF.Math.Vector2[] FlipTexCoordArrayY(GLTF.Math.Vector2[] arr)
+        {
+            for (var i = 0; i < arr.Length; i++)
+            {
+                arr[i] = FlipTexCoordY(arr[i]);
+            }
+            return arr;
+        }
+
+        public static Vector3 FlipVectorHandedness(Vector3 vector3)
+        {
+            vector3.z = -vector3.z;
+            return vector3;
+        }
+
+        public static GLTF.Math.Vector3 FlipVectorHandedness(GLTF.Math.Vector3 vector3)
+        {
+            vector3.Z = -vector3.Z;
+            return vector3;
+        }
+
+        public static Vector3[] FlipVectorArrayHandedness(Vector3[] arr)
+        {
+            for (var i = 0; i < arr.Length; i++)
+            {
+                arr[i] = FlipVectorHandedness(arr[i]);
+            }
+            return arr;
+        }
+
+        public static GLTF.Math.Vector3[] FlipVectorArrayHandedness(GLTF.Math.Vector3[] arr)
+        {
+            for (var i = 0; i < arr.Length; i++)
+            {
+                arr[i] = FlipVectorHandedness(arr[i]);
+            }
+            return arr;
+        }
+
+        public static Vector4 FlipVectorHandedness(Vector4 vector4)
+        {
+            vector4.z = -vector4.z;
+            vector4.w = -vector4.w;
+            return vector4;
+        }
+
+        public static GLTF.Math.Vector4 FlipVectorHandedness(GLTF.Math.Vector4 vector4)
+        {
+            vector4.Z = -vector4.Z;
+            vector4.W = -vector4.W;
+            return vector4;
+        }
+
+        public static Vector4[] FlipVectorArrayHandedness(Vector4[] arr)
+        {
+            for (var i = 0; i < arr.Length; i++)
+            {
+                arr[i] = FlipVectorHandedness(arr[i]);
+            }
+            return arr;
+        }
+
+        public static GLTF.Math.Vector4[] FlipVectorArrayHandedness(GLTF.Math.Vector4[] arr)
+        {
+            for (var i = 0; i < arr.Length; i++)
+            {
+                arr[i] = FlipVectorHandedness(arr[i]);
+            }
+            return arr;
+        }
+
+        public static uint[] FlipFaces(uint[] array)
+        {
+            var returnArray = new uint[array.Length];
+
+            for (int i = 0; i < array.Length; i += 3)
+            {
+                returnArray[i] = array[i + 2];
+                returnArray[i + 1] = array[i + 1];
+                returnArray[i + 2] = array[i];
+            }
+
+            return returnArray;
+        }
+
+        public static int[] FlipFaces(int[] array)
+        {
+            var returnArray = new int[array.Length];
+
+            for (int i = 0; i < array.Length; i += 3)
+            {
+                returnArray[i] = array[i + 2];
+                returnArray[i + 1] = array[i + 1];
+                returnArray[i + 2] = array[i];
+            }
+
+            return returnArray;
+        }
+    }
+}

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFUnityHelpers.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFUnityHelpers.cs
@@ -2,20 +2,45 @@
 
 namespace UnityGLTF
 {
+    /// <summary>
+    /// Contains methods which help flip a model's coordinate system.
+    /// These methods can be used to change a model's coordinate system from
+    /// the glTF standard to Unity's coordinate system. Additionally,
+    /// methods for flipping the faces of a model and for flipping a
+    /// TexCoord's Y axis to match Unity's definition are present.
+    /// </summary>
+    /// <remarks>
+    /// Methods for both UnityEngine vectors and GLTF.Math vectors are provided.
+    /// </remarks>
     public static class GLTFUnityHelpers
     {
+        /// <summary>
+        /// Flips the Y axis of a TexCoord to convert between glTF and Unity's TexCoord specification.
+        /// </summary>
+        /// <param name="vector2">The TexCoord to be converted.</param>
+        /// <returns>The converted TexCoord.</returns>
         public static Vector2 FlipTexCoordY(Vector2 vector2)
         {
             vector2.y = 1 - vector2.y;
             return vector2;
         }
 
+        /// <summary>
+        /// Flips the Y axis of a TexCoord to convert between glTF and Unity's TexCoord specification.
+        /// </summary>
+        /// <param name="vector2">The TexCoord to be converted.</param>
+        /// <returns>The converted TexCoord.</returns>
         public static GLTF.Math.Vector2 FlipTexCoordY(GLTF.Math.Vector2 vector2)
         {
             vector2.Y = 1 - vector2.Y;
             return vector2;
         }
 
+        /// <summary>
+        /// Flips the Y axis of all TexCoords in an array to convert between glTF and Unity's TexCoord specification.
+        /// </summary>
+        /// <param name="arr">The array of TexCoords to be converted.</param>
+        /// <returns>The array of converted TexCoords.</returns>
         public static Vector2[] FlipTexCoordArrayY(Vector2[] arr)
         {
             for (var i = 0; i < arr.Length; i++)
@@ -25,6 +50,11 @@ namespace UnityGLTF
             return arr;
         }
 
+        /// <summary>
+        /// Flips the Y axis of all TexCoords in an array to convert between glTF and Unity's TexCoord specification.
+        /// </summary>
+        /// <param name="arr">The array of TexCoords to be converted.</param>
+        /// <returns>The array of converted TexCoords.</returns>
         public static GLTF.Math.Vector2[] FlipTexCoordArrayY(GLTF.Math.Vector2[] arr)
         {
             for (var i = 0; i < arr.Length; i++)
@@ -34,18 +64,33 @@ namespace UnityGLTF
             return arr;
         }
 
+        /// <summary>
+        /// Inverts the Z value of a Vector3 to convert between glTF and Unity's coordinate systems.
+        /// </summary>
+        /// <param name="vector3">The Vector3 to be converted.</param>
+        /// <returns>The converted Vector3.</returns>
         public static Vector3 FlipVectorHandedness(Vector3 vector3)
         {
             vector3.z = -vector3.z;
             return vector3;
         }
 
+        /// <summary>
+        /// Inverts the Z value of a Vector3 to convert between glTF and Unity's coordinate systems.
+        /// </summary>
+        /// <param name="vector3">The Vector3 to be converted.</param>
+        /// <returns>The converted Vector3.</returns>
         public static GLTF.Math.Vector3 FlipVectorHandedness(GLTF.Math.Vector3 vector3)
         {
             vector3.Z = -vector3.Z;
             return vector3;
         }
 
+        /// <summary>
+        /// Inverts the Z value of all Vector3s in an array to convert between glTF and Unity's coordinate systems.
+        /// </summary>
+        /// <param name="arr">The array of Vector3s to be converted.</param>
+        /// <returns>The array of converted Vector3s.</returns>
         public static Vector3[] FlipVectorArrayHandedness(Vector3[] arr)
         {
             for (var i = 0; i < arr.Length; i++)
@@ -55,6 +100,11 @@ namespace UnityGLTF
             return arr;
         }
 
+        /// <summary>
+        /// Inverts the Z value of all Vector3s in an array to convert between glTF and Unity's coordinate systems.
+        /// </summary>
+        /// <param name="arr">The array of Vector3s to be converted.</param>
+        /// <returns>The array of converted Vector3s.</returns>
         public static GLTF.Math.Vector3[] FlipVectorArrayHandedness(GLTF.Math.Vector3[] arr)
         {
             for (var i = 0; i < arr.Length; i++)
@@ -64,6 +114,11 @@ namespace UnityGLTF
             return arr;
         }
 
+        /// <summary>
+        /// Inverts the Z and W values of a Vector4 to convert between glTF and Unity's coordinate systems.
+        /// </summary>
+        /// <param name="vector4">The Vector4 to be converted.</param>
+        /// <returns>The converted Vector4.</returns>
         public static Vector4 FlipVectorHandedness(Vector4 vector4)
         {
             vector4.z = -vector4.z;
@@ -71,6 +126,11 @@ namespace UnityGLTF
             return vector4;
         }
 
+        /// <summary>
+        /// Inverts the Z and W values of a Vector4 to convert between glTF and Unity's coordinate systems.
+        /// </summary>
+        /// <param name="vector4">The Vector4 to be converted.</param>
+        /// <returns>The converted Vector4.</returns>
         public static GLTF.Math.Vector4 FlipVectorHandedness(GLTF.Math.Vector4 vector4)
         {
             vector4.Z = -vector4.Z;
@@ -78,6 +138,11 @@ namespace UnityGLTF
             return vector4;
         }
 
+        /// <summary>
+        /// Inverts the Z and W values of all Vector4s in an array to convert between glTF and Unity's coordinate systems.
+        /// </summary>
+        /// <param name="arr">The array of Vector4s to be converted.</param>
+        /// <returns>The array of converted Vector4s.</returns>
         public static Vector4[] FlipVectorArrayHandedness(Vector4[] arr)
         {
             for (var i = 0; i < arr.Length; i++)
@@ -87,6 +152,11 @@ namespace UnityGLTF
             return arr;
         }
 
+        /// <summary>
+        /// Inverts the Z and W values of all Vector4s in an array to convert between glTF and Unity's coordinate systems.
+        /// </summary>
+        /// <param name="arr">The array of Vector4s to be converted.</param>
+        /// <returns>The array of converted Vector4s.</returns>
         public static GLTF.Math.Vector4[] FlipVectorArrayHandedness(GLTF.Math.Vector4[] arr)
         {
             for (var i = 0; i < arr.Length; i++)
@@ -96,6 +166,11 @@ namespace UnityGLTF
             return arr;
         }
 
+        /// <summary>
+        /// Flips the faces of a model by changing the order of the index array.
+        /// </summary>
+        /// <param name="array">An array of uints, representing the indices to be rotated.</param>
+        /// <returns>The flipped array of indices.</returns>
         public static uint[] FlipFaces(uint[] array)
         {
             var returnArray = new uint[array.Length];
@@ -110,6 +185,11 @@ namespace UnityGLTF
             return returnArray;
         }
 
+        /// <summary>
+        /// Flips the faces of a model by changing the order of the index array.
+        /// </summary>
+        /// <param name="arr">An array of ints, representing the indices to be rotated.</param>
+        /// <returns>The flipped array of indices.</returns>
         public static int[] FlipFaces(int[] array)
         {
             var returnArray = new int[array.Length];

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFUnityHelpers.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFUnityHelpers.cs
@@ -15,155 +15,165 @@ namespace UnityGLTF
     public static class GLTFUnityHelpers
     {
         /// <summary>
-        /// Flips the Y axis of a TexCoord to convert between glTF and Unity's TexCoord specification.
+        /// Flips the V component of a TexCoord to convert between glTF and Unity's TexCoord specification.
         /// </summary>
-        /// <param name="vector2">The TexCoord to be converted.</param>
+        /// <param name="vector">The TexCoord to be converted.</param>
         /// <returns>The converted TexCoord.</returns>
-        public static Vector2 FlipTexCoordY(Vector2 vector2)
+        public static Vector2 FlipTexCoordV(Vector2 vector)
         {
-            vector2.y = 1 - vector2.y;
-            return vector2;
+            return new Vector2(vector.x, 1.0f - vector.y);
         }
 
         /// <summary>
-        /// Flips the Y axis of a TexCoord to convert between glTF and Unity's TexCoord specification.
+        /// Flips the V component of a TexCoord to convert between glTF and Unity's TexCoord specification.
         /// </summary>
-        /// <param name="vector2">The TexCoord to be converted.</param>
+        /// <param name="vector">The TexCoord to be converted.</param>
         /// <returns>The converted TexCoord.</returns>
-        public static GLTF.Math.Vector2 FlipTexCoordY(GLTF.Math.Vector2 vector2)
+        public static GLTF.Math.Vector2 FlipTexCoordV(GLTF.Math.Vector2 vector)
         {
-            vector2.Y = 1 - vector2.Y;
-            return vector2;
+            return new GLTF.Math.Vector2(vector.X, 1.0f - vector.Y);
         }
 
         /// <summary>
-        /// Flips the Y axis of all TexCoords in an array to convert between glTF and Unity's TexCoord specification.
+        /// Flips the V component of all TexCoords in an array to convert between glTF and Unity's TexCoord specification.
         /// </summary>
-        /// <param name="arr">The array of TexCoords to be converted.</param>
+        /// <param name="array">The array of TexCoords to be converted.</param>
         /// <returns>The array of converted TexCoords.</returns>
-        public static Vector2[] FlipTexCoordArrayY(Vector2[] arr)
+        public static Vector2[] FlipTexCoordArrayV(Vector2[] array)
         {
-            for (var i = 0; i < arr.Length; i++)
+            var returnArray = new Vector2[array.Length];
+
+            for (var i = 0; i < array.Length; i++)
             {
-                arr[i] = FlipTexCoordY(arr[i]);
+                returnArray[i] = FlipTexCoordV(array[i]);
             }
-            return arr;
+
+            return returnArray;
         }
 
         /// <summary>
-        /// Flips the Y axis of all TexCoords in an array to convert between glTF and Unity's TexCoord specification.
+        /// Flips the V component of all TexCoords in an array to convert between glTF and Unity's TexCoord specification.
         /// </summary>
-        /// <param name="arr">The array of TexCoords to be converted.</param>
+        /// <param name="array">The array of TexCoords to be converted.</param>
         /// <returns>The array of converted TexCoords.</returns>
-        public static GLTF.Math.Vector2[] FlipTexCoordArrayY(GLTF.Math.Vector2[] arr)
+        public static GLTF.Math.Vector2[] FlipTexCoordArrayV(GLTF.Math.Vector2[] array)
         {
-            for (var i = 0; i < arr.Length; i++)
+            var returnArray = new GLTF.Math.Vector2[array.Length];
+
+            for (var i = 0; i < array.Length; i++)
             {
-                arr[i] = FlipTexCoordY(arr[i]);
+                returnArray[i] = FlipTexCoordV(array[i]);
             }
-            return arr;
+
+            return returnArray;
         }
 
         /// <summary>
         /// Inverts the Z value of a Vector3 to convert between glTF and Unity's coordinate systems.
         /// </summary>
-        /// <param name="vector3">The Vector3 to be converted.</param>
+        /// <param name="vector">The Vector3 to be converted.</param>
         /// <returns>The converted Vector3.</returns>
-        public static Vector3 FlipVectorHandedness(Vector3 vector3)
+        public static Vector3 FlipVectorHandedness(Vector3 vector)
         {
-            vector3.z = -vector3.z;
-            return vector3;
+            return new Vector3(vector.x, vector.y, -vector.z);
         }
 
         /// <summary>
         /// Inverts the Z value of a Vector3 to convert between glTF and Unity's coordinate systems.
         /// </summary>
-        /// <param name="vector3">The Vector3 to be converted.</param>
+        /// <param name="vector">The Vector3 to be converted.</param>
         /// <returns>The converted Vector3.</returns>
-        public static GLTF.Math.Vector3 FlipVectorHandedness(GLTF.Math.Vector3 vector3)
+        public static GLTF.Math.Vector3 FlipVectorHandedness(GLTF.Math.Vector3 vector)
         {
-            vector3.Z = -vector3.Z;
-            return vector3;
+            return new GLTF.Math.Vector3(vector.X, vector.Y, -vector.Z);
         }
 
         /// <summary>
         /// Inverts the Z value of all Vector3s in an array to convert between glTF and Unity's coordinate systems.
         /// </summary>
-        /// <param name="arr">The array of Vector3s to be converted.</param>
+        /// <param name="array">The array of Vector3s to be converted.</param>
         /// <returns>The array of converted Vector3s.</returns>
-        public static Vector3[] FlipVectorArrayHandedness(Vector3[] arr)
+        public static Vector3[] FlipVectorArrayHandedness(Vector3[] array)
         {
-            for (var i = 0; i < arr.Length; i++)
+            var returnArray = new Vector3[array.Length];
+
+            for (var i = 0; i < array.Length; i++)
             {
-                arr[i] = FlipVectorHandedness(arr[i]);
+                returnArray[i] = FlipVectorHandedness(array[i]);
             }
-            return arr;
+
+            return returnArray;
         }
 
         /// <summary>
         /// Inverts the Z value of all Vector3s in an array to convert between glTF and Unity's coordinate systems.
         /// </summary>
-        /// <param name="arr">The array of Vector3s to be converted.</param>
+        /// <param name="array">The array of Vector3s to be converted.</param>
         /// <returns>The array of converted Vector3s.</returns>
-        public static GLTF.Math.Vector3[] FlipVectorArrayHandedness(GLTF.Math.Vector3[] arr)
+        public static GLTF.Math.Vector3[] FlipVectorArrayHandedness(GLTF.Math.Vector3[] array)
         {
-            for (var i = 0; i < arr.Length; i++)
+            var returnArray = new GLTF.Math.Vector3[array.Length];
+
+            for (var i = 0; i < array.Length; i++)
             {
-                arr[i] = FlipVectorHandedness(arr[i]);
+                returnArray[i] = FlipVectorHandedness(array[i]);
             }
-            return arr;
+
+            return returnArray;
         }
 
         /// <summary>
         /// Inverts the Z and W values of a Vector4 to convert between glTF and Unity's coordinate systems.
         /// </summary>
-        /// <param name="vector4">The Vector4 to be converted.</param>
+        /// <param name="vector">The Vector4 to be converted.</param>
         /// <returns>The converted Vector4.</returns>
-        public static Vector4 FlipVectorHandedness(Vector4 vector4)
+        public static Vector4 FlipVectorHandedness(Vector4 vector)
         {
-            vector4.z = -vector4.z;
-            vector4.w = -vector4.w;
-            return vector4;
+            return new Vector4(vector.x, vector.y, -vector.z, -vector.w);
         }
 
         /// <summary>
         /// Inverts the Z and W values of a Vector4 to convert between glTF and Unity's coordinate systems.
         /// </summary>
-        /// <param name="vector4">The Vector4 to be converted.</param>
+        /// <param name="vector">The Vector4 to be converted.</param>
         /// <returns>The converted Vector4.</returns>
-        public static GLTF.Math.Vector4 FlipVectorHandedness(GLTF.Math.Vector4 vector4)
+        public static GLTF.Math.Vector4 FlipVectorHandedness(GLTF.Math.Vector4 vector)
         {
-            vector4.Z = -vector4.Z;
-            vector4.W = -vector4.W;
-            return vector4;
+            return new GLTF.Math.Vector4(vector.X, vector.Y, -vector.Z, -vector.W);
         }
 
         /// <summary>
         /// Inverts the Z and W values of all Vector4s in an array to convert between glTF and Unity's coordinate systems.
         /// </summary>
-        /// <param name="arr">The array of Vector4s to be converted.</param>
+        /// <param name="array">The array of Vector4s to be converted.</param>
         /// <returns>The array of converted Vector4s.</returns>
-        public static Vector4[] FlipVectorArrayHandedness(Vector4[] arr)
+        public static Vector4[] FlipVectorArrayHandedness(Vector4[] array)
         {
-            for (var i = 0; i < arr.Length; i++)
+            var returnArray = new Vector4[array.Length];
+
+            for (var i = 0; i < array.Length; i++)
             {
-                arr[i] = FlipVectorHandedness(arr[i]);
+                returnArray[i] = FlipVectorHandedness(array[i]);
             }
-            return arr;
+
+            return returnArray;
         }
 
         /// <summary>
         /// Inverts the Z and W values of all Vector4s in an array to convert between glTF and Unity's coordinate systems.
         /// </summary>
-        /// <param name="arr">The array of Vector4s to be converted.</param>
+        /// <param name="array">The array of Vector4s to be converted.</param>
         /// <returns>The array of converted Vector4s.</returns>
-        public static GLTF.Math.Vector4[] FlipVectorArrayHandedness(GLTF.Math.Vector4[] arr)
+        public static GLTF.Math.Vector4[] FlipVectorArrayHandedness(GLTF.Math.Vector4[] array)
         {
-            for (var i = 0; i < arr.Length; i++)
+            var returnArray = new GLTF.Math.Vector4[array.Length];
+
+            for (var i = 0; i < array.Length; i++)
             {
-                arr[i] = FlipVectorHandedness(arr[i]);
+                returnArray[i] = FlipVectorHandedness(array[i]);
             }
-            return arr;
+
+            return returnArray;
         }
 
         /// <summary>
@@ -188,7 +198,7 @@ namespace UnityGLTF
         /// <summary>
         /// Flips the faces of a model by changing the order of the index array.
         /// </summary>
-        /// <param name="arr">An array of ints, representing the indices to be rotated.</param>
+        /// <param name="array">An array of ints, representing the indices to be rotated.</param>
         /// <returns>The flipped array of indices.</returns>
         public static int[] FlipFaces(int[] array)
         {

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFUnityHelpers.cs.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFUnityHelpers.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 66146a0d68d2da843882945681998dbf
+timeCreated: 1515621179
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR refactors several places where the coordinate space conversion was happening out into a static `UnityGLTFHelpers` class. It removes coordinate space switching from the GLTFSerialization layer and adds it to the UnityGLTF layer. This also adds Z negation (in addition to the previously existing W negation) when converting a Vector4.

Additionally, a small issue with building the file path to the StreamingAssets folder was fixed.

Fixes #69 and fixes #75.