### PR TITLE
Adding Unity 2017.2 and 2017.3 support, as well as additional UWP support

### DIFF
--- a/UnityGLTF/.gitignore
+++ b/UnityGLTF/.gitignore
@@ -7,6 +7,7 @@
 /Assets/AssetStoreTools*
 /Assets/ShaderForge*
 /Assets/VSCode*
+/UnityPackageManager/
 
 # Visual Studio 2015 cache directory
 /.vs/
@@ -28,7 +29,6 @@ ExportedObj/
 *.svd
 *.pdb
 
-
 # Unity3D generated meta files
 *.pidb.meta
 
@@ -40,3 +40,8 @@ sysinfo.txt
 *.unitypackage
 
 /www/node_modules/
+
+# UWP-specific folders and files
+/[Aa]pp/
+/UWP/
+WSATestCertificate.pfx*

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Async/AsyncAction.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Async/AsyncAction.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections;
+#if WINDOWS_UWP
+using System.Threading.Tasks;
+#else
 using System.Threading;
+#endif
 
 namespace UnityGLTF
 {
@@ -12,12 +16,15 @@ namespace UnityGLTF
 		private bool _workerThreadRunning = false;
 		private Exception _savedException;
 
-#if !WINDOWS_UWP
 		public IEnumerator RunOnWorkerThread(Action action)
 		{
 			_workerThreadRunning = true;
 
+#if WINDOWS_UWP
+			Task.Factory.StartNew(() =>
+#else
 			ThreadPool.QueueUserWorkItem((_) =>
+#endif
 			{
 				try
 				{
@@ -46,6 +53,5 @@ namespace UnityGLTF
 				yield return null;
 			}
 		}
-#endif
 	}
 }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -189,13 +189,12 @@ namespace UnityGLTF
 						yield return LoadImage(_gltfDirectoryPath, image, i);
 					}
 				}
-#if !WINDOWS_UWP
+
 				// generate these in advance instead of as-needed
 				if (isMultithreaded)
 				{
 					yield return _asyncAction.RunOnWorkerThread(() => BuildAttributesForMeshes());
 				}
-#endif
 			}
 
 			var sceneObj = CreateScene(scene);

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -100,7 +100,11 @@ namespace UnityGLTF
 			{
 				var www = UnityWebRequest.Get(_gltfUrl);
 
+#if UNITY_2017_2_OR_NEWER
+				yield return www.SendWebRequest();
+#else
 				yield return www.Send();
+#endif
 
 				if (www.responseCode >= 400 || www.responseCode == 0)
 				{
@@ -706,7 +710,11 @@ namespace UnityGLTF
 						var www = UnityWebRequest.Get(Path.Combine(rootPath, uri));
 						www.downloadHandler = new DownloadHandlerTexture();
 
+#if UNITY_2017_2_OR_NEWER
+						yield return www.SendWebRequest();
+#else
 						yield return www.Send();
+#endif
 
 						// HACK to enable mipmaps :(
 						var tempTexture = DownloadHandlerTexture.GetContent(www);
@@ -774,7 +782,11 @@ namespace UnityGLTF
 				{
 					var www = UnityWebRequest.Get(Path.Combine(sourceUri, uri));
 
+#if UNITY_2017_2_OR_NEWER
+					yield return www.SendWebRequest();
+#else
 					yield return www.Send();
+#endif
 
 					bufferData = www.downloadHandler.data;
 				}

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Editor/GLTFBenchmark.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Editor/GLTFBenchmark.cs
@@ -31,7 +31,12 @@ public class GLTFBenchmark : MonoBehaviour
 		foreach (var gltfUrl in GLTFUrls)
 		{
 			var www = UnityWebRequest.Get(gltfUrl);
+
+#if UNITY_2017_2_OR_NEWER
+			yield return www.SendWebRequest();
+#else
 			yield return www.Send();
+#endif
 
 			Debug.LogFormat("Benchmarking: {0}", gltfUrl);
 			long totalTime = 0;

--- a/UnityGLTF/Assets/UnityTestTools/Assertions/Editor/AssertionComponentEditor.cs
+++ b/UnityGLTF/Assets/UnityTestTools/Assertions/Editor/AssertionComponentEditor.cs
@@ -39,9 +39,15 @@ namespace UnityTest
 			var script = (AssertionComponent)target;
 			EditorGUILayout.BeginHorizontal();
 			var obj = DrawComparerSelection(script);
+#if UNITY_2017_3_OR_NEWER
+			script.checkMethods = (CheckMethod)EditorGUILayout.EnumFlagsField(script.checkMethods,
+																			  EditorStyles.popup,
+																			  GUILayout.ExpandWidth(false));
+#else
 			script.checkMethods = (CheckMethod)EditorGUILayout.EnumMaskField(script.checkMethods,
 																			 EditorStyles.popup,
 																			 GUILayout.ExpandWidth(false));
+#endif
 			EditorGUILayout.EndHorizontal();
 
 			if (script.IsCheckMethodSelected(CheckMethod.AfterPeriodOfTime))

--- a/UnityGLTF/Assets/UnityTestTools/Assertions/Editor/AssertionListRenderer.cs
+++ b/UnityGLTF/Assets/UnityTestTools/Assertions/Editor/AssertionListRenderer.cs
@@ -197,9 +197,15 @@ namespace UnityTest
 
 
 			EditorGUILayout.BeginVertical(GUILayout.MaxWidth(250));
+#if UNITY_2017_3_OR_NEWER
+			EditorGUILayout.EnumFlagsField(assertionComponent.checkMethods,
+										   EditorStyles.popup,
+										   GUILayout.MaxWidth(150));
+#else
 			EditorGUILayout.EnumMaskField(assertionComponent.checkMethods,
 										  EditorStyles.popup,
 										  GUILayout.MaxWidth(150));
+#endif
 			EditorGUILayout.EndVertical();
 
 

--- a/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/Batch.cs
+++ b/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/Batch.cs
@@ -68,7 +68,7 @@ namespace UnityTest
 				port = port
 			};
 
-#if !UNITY_2017
+#if !UNITY_2017_1_OR_NEWER
 			if (Application.isWebPlayer)
 			{
 				config.sendResultsOverNetwork = false;

--- a/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/IntegrationTestsRunnerWindow.cs
+++ b/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/IntegrationTestsRunnerWindow.cs
@@ -61,13 +61,26 @@ namespace UnityTest
 			EditorApplication.hierarchyWindowChanged += OnHierarchyChangeUpdate;
 			EditorApplication.update -= BackgroundSceneChangeWatch;
 			EditorApplication.update += BackgroundSceneChangeWatch;
+#if UNITY_2017_2_OR_NEWER
+			EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+			EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+#else
 			EditorApplication.playmodeStateChanged -= OnPlaymodeStateChanged;
 			EditorApplication.playmodeStateChanged += OnPlaymodeStateChanged;
+#endif
 		}
 
+#if UNITY_2017_2_OR_NEWER
+		private static void OnPlayModeStateChanged(PlayModeStateChange stateChange)
+#else
 		private static void OnPlaymodeStateChanged()
+#endif
 		{
-			if (s_Instance && EditorApplication.isPlaying  == EditorApplication.isPlayingOrWillChangePlaymode)
+#if UNITY_2017_2_OR_NEWER
+			if (s_Instance && stateChange == PlayModeStateChange.EnteredPlayMode || stateChange == PlayModeStateChange.EnteredEditMode)
+#else
+			if (s_Instance && EditorApplication.isPlaying == EditorApplication.isPlayingOrWillChangePlaymode)
+#endif
 				s_Instance.RebuildTestList();
 		}
 
@@ -76,7 +89,11 @@ namespace UnityTest
 			EditorApplication.hierarchyWindowItemOnGUI -= OnHierarchyWindowItemDraw;
 			EditorApplication.update -= BackgroundSceneChangeWatch;
 			EditorApplication.hierarchyWindowChanged -= OnHierarchyChangeUpdate;
+#if UNITY_2017_2_OR_NEWER
+			EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
+#else
 			EditorApplication.playmodeStateChanged -= OnPlaymodeStateChanged;
+#endif
 
 			TestComponent.DestroyAllDynamicTests();
 		}

--- a/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/PlatformRunner/PlatformRunnerSettingsWindow.cs
+++ b/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/PlatformRunner/PlatformRunnerSettingsWindow.cs
@@ -182,7 +182,11 @@ namespace UnityTest.IntegrationTests
 				var rect = GUILayoutUtility.GetRect(guiContent, EditorStyles.label);
 				if (rect.Contains(Event.current.mousePosition))
 				{
+#if UNITY_2017_3_OR_NEWER
+					if (Event.current.type == EventType.MouseDown && Event.current.button == 0)
+#else
 					if (Event.current.type == EventType.mouseDown && Event.current.button == 0)
+#endif
 					{
 						selectString = scenePath;
 						Event.current.Use();

--- a/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/Renderer/IntegrationTestLine.cs
+++ b/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/Renderer/IntegrationTestLine.cs
@@ -17,7 +17,11 @@ namespace UnityTest
 
 		protected internal override void DrawLine(Rect rect, GUIContent label, bool isSelected, RenderingOptions options)
 		{
-			if(Event.current.type != EventType.repaint)
+#if UNITY_2017_3_OR_NEWER
+			if (Event.current.type != EventType.Repaint)
+#else
+			if (Event.current.type != EventType.repaint)
+#endif
 				return;
 
 			Styles.testName.Draw (rect, label, false, false, false, isSelected);

--- a/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/Renderer/IntegrationTestRendererBase.cs
+++ b/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/Renderer/IntegrationTestRendererBase.cs
@@ -91,7 +91,11 @@ namespace UnityTest
 
 		protected void OnLeftMouseButtonClick(Rect rect)
 		{
+#if UNITY_2017_3_OR_NEWER
+			if (rect.Contains(Event.current.mousePosition) && Event.current.type == EventType.MouseDown && Event.current.button == 0)
+#else
 			if (rect.Contains(Event.current.mousePosition) && Event.current.type == EventType.mouseDown && Event.current.button == 0)
+#endif
 			{
 				rect.width = 20;
 				if (rect.Contains(Event.current.mousePosition)) return;


### PR DESCRIPTION
This PR adds a few newly generated folders for both UWP and Unity 2017 to the gitignore.

It also add versioning `#if` statements where APIs have changed between Unity versions.