### PR TITLE
Fixing loading from StreamingAssets

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 
 namespace UnityGLTF
 {
-
 	/// <summary>
 	/// Component to load a GLTF scene with
 	/// </summary>
@@ -23,6 +22,11 @@ namespace UnityGLTF
 			FileStream gltfStream = null;
 			if (UseStream)
 			{
+				// Path.Combine treats paths that start with the separator character
+				// as absolute paths, ignoring the first path passed in. This removes
+				// that character to properly handle a filename written with it.
+				Url = Url.TrimStart(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar });
+
 				var fullPath = Path.Combine(Application.streamingAssetsPath, Url);
 				gltfStream = File.OpenRead(fullPath);
 				loader = new GLTFSceneImporter(
@@ -43,6 +47,7 @@ namespace UnityGLTF
 
             loader.MaximumLod = MaximumLod;
 			yield return loader.Load(-1, Multithreaded);
+
 			if (gltfStream != null)
 			{
 #if WINDOWS_UWP

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -101,6 +101,10 @@ namespace UnityGLTF
 				byte[] gltfData = www.downloadHandler.data;
 				_gltfStream.Stream = new MemoryStream(gltfData, 0, gltfData .Length, false, true);
 			}
+			else if (_loadType == LoadType.Stream)
+			{
+				// Do nothing, since the stream was passed in via the constructor.
+			}
 			else
 			{
 				throw new Exception("Invalid load type specified: " + _loadType);

--- a/UnityGLTF/Assets/UnityGLTF/Shaders/ShaderRetention/normal.jpg.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Shaders/ShaderRetention/normal.jpg.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: 9ae95f298490a7b4d816251d4e2555d7
-timeCreated: 1517615515
+timeCreated: 1518638449
 licenseType: Pro
 TextureImporter:
   fileIDToRecycleName: {}
@@ -8,7 +8,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -44,7 +44,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   maxTextureSizeSet: 0
   compressionQualitySet: 0


### PR DESCRIPTION
This PR re-adds `LoadType.Stream` to GLTFSceneImporter.Load (removed in #104). Otherwise, attempting to lead from StreamingAssets by checking the "Use Stream" box on a GLTF Component throws the "Invalid load type specified" Exception, even though `LoadType.Stream` is supported.

It also trims the beginning of the passed in filename, due to a quirk in `Path.Combine`, found in the way some of the example scenes, like UWPTestScene, specify the filename.

This PR also includes a .meta file that was missing and updates a normal map to be properly denoted as a normal map in Unity.