### PR TITLE
ScriptedImporter support

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
@@ -1,0 +1,388 @@
+#if UNITY_2017_1_OR_NEWER
+using UnityEditor.Experimental.AssetImporters;
+using UnityEditor;
+using System.IO;
+using UnityEngine;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using Object = UnityEngine.Object;
+using System.Collections;
+
+namespace UnityGLTF
+{
+    [ScriptedImporter(1, new[] { "glb" })]
+    public class GLTFImporter : ScriptedImporter
+    {
+        [SerializeField] private bool _removeEmptyRootObjects = true;
+        [SerializeField] private float _scaleFactor = 1.0f;
+        [SerializeField] private int _maximumLod = 300;
+        [SerializeField] private bool _readWriteEnabled = true;
+        [SerializeField] private bool _generateColliders = false;
+        [SerializeField] private bool _swapUvs = false;
+        [SerializeField] private GLTFImporterNormals _importNormals = GLTFImporterNormals.Import;
+        [SerializeField] private bool _importMaterials = true;
+		[SerializeField] private bool _useJpgTextures = false;
+
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+			string sceneName = null;
+            GameObject gltfScene = null;
+            UnityEngine.Mesh[] meshes = null;
+            try
+            {
+				sceneName = Path.GetFileNameWithoutExtension(ctx.assetPath);
+                gltfScene = CreateGLTFScene(ctx.assetPath);
+
+                // Remove empty roots
+                if (_removeEmptyRootObjects)
+                {
+                    var t = gltfScene.transform;
+                    while (
+                        gltfScene.transform.childCount == 1 &&
+                        gltfScene.GetComponents<Component>().Length == 1)
+                    {
+                        var parent = gltfScene;
+                        gltfScene = gltfScene.transform.GetChild(0).gameObject;
+                        t = gltfScene.transform;
+                        t.parent = null; // To keep transform information in the new parent
+                        Object.DestroyImmediate(parent); // Get rid of the parent
+                    }
+                }
+
+                // Ensure there are no hide flags present (will cause problems when saving)
+                gltfScene.hideFlags &= ~(HideFlags.HideAndDontSave);
+                foreach (Transform child in gltfScene.transform)
+                {
+                    child.gameObject.hideFlags &= ~(HideFlags.HideAndDontSave);
+                }
+
+                // Zero position
+                gltfScene.transform.position = Vector3.zero;
+
+                // Get meshes
+                var meshNames = new List<string>();
+                var meshHash = new HashSet<UnityEngine.Mesh>();
+                var meshFilters = gltfScene.GetComponentsInChildren<MeshFilter>();
+                var vertexBuffer = new List<Vector3>();
+                meshes = meshFilters.Select(mf =>
+                {
+                    var mesh = mf.sharedMesh;
+                    vertexBuffer.Clear();
+                    mesh.GetVertices(vertexBuffer);
+                    for (var i = 0; i < vertexBuffer.Count; ++i)
+                    {
+                        vertexBuffer[i] *= _scaleFactor;
+                    }
+                    mesh.SetVertices(vertexBuffer);
+                    if (_swapUvs)
+                    {
+                        var uv = mesh.uv;
+                        var uv2 = mesh.uv2;
+                        mesh.uv = uv2;
+                        mesh.uv2 = uv2;
+                    }
+                    if (_importNormals == GLTFImporterNormals.None)
+                    {
+                        mesh.normals = new Vector3[0];
+                    }
+                    if (_importNormals == GLTFImporterNormals.Calculate)
+                    {
+                        mesh.RecalculateNormals();
+                    }
+                    mesh.UploadMeshData(!_readWriteEnabled);
+
+                    if (_generateColliders)
+                    {
+                        var collider = mf.gameObject.AddComponent<MeshCollider>();
+                        collider.sharedMesh = mesh;
+                    }
+
+                    if (meshHash.Add(mesh))
+                    {
+                        var meshName = string.IsNullOrEmpty(mesh.name) ? mf.gameObject.name : mesh.name;
+                        mesh.name = ObjectNames.GetUniqueName(meshNames.ToArray(), meshName);
+                        meshNames.Add(mesh.name);
+                    }
+
+                    return mesh;
+                }).ToArray();
+
+                var renderers = gltfScene.GetComponentsInChildren<Renderer>();
+
+                if (_importMaterials)
+                {
+                    // Get materials
+                    var materialNames = new List<string>();
+                    var materialHash = new HashSet<UnityEngine.Material>();
+                    var materials = renderers.SelectMany(r =>
+                    {
+                        return r.sharedMaterials.Select(mat =>
+                        {
+                            if (materialHash.Add(mat))
+                            {
+                                var matName = string.IsNullOrEmpty(mat.name) ? mat.shader.name : mat.name;
+                                if (matName == mat.shader.name)
+                                {
+                                    matName = matName.Substring(Mathf.Min(matName.LastIndexOf("/") + 1, matName.Length - 1));
+                                }
+
+								// Ensure name is unique
+								matName = string.Format("{0} {1}", sceneName, ObjectNames.NicifyVariableName(matName));
+								matName = ObjectNames.GetUniqueName(materialNames.ToArray(), matName);
+
+								mat.name = matName;
+								materialNames.Add(matName);
+                            }
+
+                            return mat;
+                        });
+                    }).ToArray();
+
+                    // Get textures
+                    var textureNames = new List<string>();
+                    var textureHash = new HashSet<Texture2D>();
+                    var texMaterialMap = new Dictionary<Texture2D, List<TexMaterialMap>>();
+                    var textures = materials.SelectMany(mat =>
+                    {
+                        var shader = mat.shader;
+                        if (!shader) return Enumerable.Empty<Texture2D>();
+
+                        var matTextures = new List<Texture2D>();
+                        for (var i = 0; i < ShaderUtil.GetPropertyCount(shader); ++i)
+                        {
+                            if (ShaderUtil.GetPropertyType(shader, i) == ShaderUtil.ShaderPropertyType.TexEnv)
+                            {
+                                var propertyName = ShaderUtil.GetPropertyName(shader, i);
+                                var tex = mat.GetTexture(propertyName) as Texture2D;
+                                if (tex)
+                                {
+                                    if (textureHash.Add(tex))
+                                    {
+                                        var texName = tex.name;
+                                        if (string.IsNullOrEmpty(texName))
+                                        {
+                                            if (propertyName.StartsWith("_")) texName = propertyName.Substring(Mathf.Min(1, propertyName.Length - 1));
+                                        }
+
+										// Ensure name is unique
+										texName = string.Format("{0} {1}", sceneName, ObjectNames.NicifyVariableName(texName));
+                                        texName = ObjectNames.GetUniqueName(textureNames.ToArray(), texName);
+
+										tex.name = texName;
+                                        textureNames.Add(texName);
+                                        matTextures.Add(tex);
+                                    }
+
+                                    List<TexMaterialMap> materialMaps;
+                                    if (!texMaterialMap.TryGetValue(tex, out materialMaps))
+                                    {
+                                        materialMaps = new List<TexMaterialMap>();
+                                        texMaterialMap.Add(tex, materialMaps);
+                                    }
+
+                                    materialMaps.Add(new TexMaterialMap(mat, propertyName, propertyName == "_BumpMap"));
+                                }
+                            }
+                        }
+                        return matTextures;
+                    }).ToArray();
+
+                    var folderName = Path.GetDirectoryName(ctx.assetPath);
+
+                    // Save textures as separate assets and rewrite refs
+                    // TODO: Support for other texture types
+                    if (textures.Length > 0)
+                    {
+                        var texturesRoot = string.Concat(folderName, "/", "Textures/");
+                        Directory.CreateDirectory(texturesRoot);
+
+                        foreach (var tex in textures)
+                        {
+							var ext = _useJpgTextures ? ".jpg" : ".png";
+                            var texPath = string.Concat(texturesRoot, tex.name, ext);
+                            File.WriteAllBytes(texPath, _useJpgTextures ? tex.EncodeToJPG() : tex.EncodeToPNG());
+
+                            AssetDatabase.ImportAsset(texPath);
+                        }
+                    }
+
+                    // Save materials as separate assets and rewrite refs
+                    if (materials.Length > 0)
+                    {
+                        var materialRoot = string.Concat(folderName, "/", "Materials/");
+                        Directory.CreateDirectory(materialRoot);
+
+                        foreach (var mat in materials)
+                        {
+                            var materialPath = string.Concat(materialRoot, mat.name, ".mat");
+                            var newMat = mat;
+                            CopyOrNew(mat, materialPath, m =>
+                            {
+                                // Fix references
+                                newMat = m;
+                                foreach (var r in renderers)
+                                {
+                                    var sharedMaterials = r.sharedMaterials;
+                                    for (var i = 0; i < sharedMaterials.Length; ++i)
+                                    {
+                                        var sharedMaterial = sharedMaterials[i];
+                                        if (sharedMaterial.name == mat.name) sharedMaterials[i] = m;
+                                    }
+                                    sharedMaterials = sharedMaterials.Where(sm => sm).ToArray();
+                                    r.sharedMaterials = sharedMaterials;
+                                }
+                            });
+                            // Fix textures
+							// HACK: This needs to be a delayed call.
+							// Unity needs a frame to kick off the texture import so we can rewrite the ref
+                            if (textures.Length > 0)
+                            {
+                                EditorApplication.delayCall += () =>
+                                {
+                                    for (var i = 0; i < textures.Length; ++i)
+                                    {
+                                        var tex = textures[i];
+                                        var texturesRoot = string.Concat(folderName, "/", "Textures/");
+										var ext = _useJpgTextures ? ".jpg" : ".png";
+                                        var texPath = string.Concat(texturesRoot, tex.name, ext);
+
+                                        // Grab new imported texture
+                                        var materialMaps = texMaterialMap[tex];
+                                        var importer = (TextureImporter)TextureImporter.GetAtPath(texPath);
+                                        var importedTex = AssetDatabase.LoadAssetAtPath<Texture2D>(texPath);
+                                        if (importer != null)
+                                        {
+                                            var isNormalMap = false;
+                                            foreach (var materialMap in materialMaps)
+                                            {
+                                                if (materialMap.Material == mat)
+                                                {
+                                                    isNormalMap |= materialMap.IsNormalMap;
+                                                    newMat.SetTexture(materialMap.Property, importedTex);
+                                                }
+                                            };
+
+                                            if (isNormalMap)
+                                            {
+                                                // Try to auto-detect normal maps
+                                                importer.textureType = TextureImporterType.NormalMap;
+                                            }
+                                            else if (importer.textureType == TextureImporterType.Sprite)
+                                            {
+                                                // Force disable sprite mode, even for 2D projects
+                                                importer.textureType = TextureImporterType.Default;
+                                            }
+
+                                            importer.SaveAndReimport();
+                                        }
+										else
+										{
+											Debug.LogWarning(string.Format("GLTFImporter: Unable to import texture at path: {0}", texPath));
+										}
+                                    }
+                                };
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    var temp = GameObject.CreatePrimitive(PrimitiveType.Plane);
+                    temp.SetActive(false);
+                    var defaultMat = new[] { temp.GetComponent<Renderer>().sharedMaterial };
+                    DestroyImmediate(temp);
+
+                    foreach (var rend in renderers)
+                    {
+                        rend.sharedMaterials = defaultMat;
+                    }
+                }
+            }
+            catch
+            {
+                if (gltfScene) DestroyImmediate(gltfScene);
+                throw;
+            }
+
+#if UNITY_2017_3_OR_NEWER
+            // Set main asset
+            ctx.AddObjectToAsset("main asset", gltfScene);
+
+            // Add meshes
+            foreach (var mesh in meshes)
+            {
+                ctx.AddObjectToAsset("mesh " + mesh.name, mesh);
+            }
+
+            ctx.SetMainObject(gltfScene);
+#else
+            // Set main asset
+            ctx.SetMainAsset("main asset", gltfScene);
+
+            // Add meshes
+            foreach (var mesh in meshes)
+            {
+                ctx.AddSubAsset("mesh " + mesh.name, mesh);
+            }
+#endif
+        }
+
+        private GameObject CreateGLTFScene(string projectFilePath)
+        {
+			using (var stream = File.OpenRead(projectFilePath))
+			{
+				var loader = new GLTFSceneImporter(projectFilePath, stream);
+
+				loader.MaximumLod = _maximumLod;
+
+				// HACK: Force the coroutine to run synchronously in the editor
+				var stack = new Stack<IEnumerator>();
+				stack.Push(loader.Load(isMultithreaded: true));
+
+				while (stack.Count > 0)
+				{
+					var enumerator = stack.Pop();
+					if (enumerator.MoveNext())
+					{
+						stack.Push(enumerator);
+						var subEnumerator = enumerator.Current as IEnumerator;
+						if (subEnumerator != null)
+						{
+							stack.Push(subEnumerator);
+						}
+					}
+				}
+				return loader.LastLoadedScene;
+			}
+        }
+
+        private void CopyOrNew<T>(T asset, string assetPath, Action<T> replaceReferences) where T : Object
+        {
+            var existingAsset = AssetDatabase.LoadAssetAtPath<T>(assetPath);
+            if (existingAsset)
+            {
+                EditorUtility.CopySerialized(asset, existingAsset);
+                replaceReferences(existingAsset);
+                return;
+            }
+
+            AssetDatabase.CreateAsset(asset, assetPath);
+        }
+
+        private class TexMaterialMap
+        {
+            public UnityEngine.Material Material { get; set; }
+            public string Property { get; set; }
+            public bool IsNormalMap { get; set; }
+
+            public TexMaterialMap(UnityEngine.Material material, string property, bool isNormalMap)
+            {
+                Material = material;
+                Property = property;
+                IsNormalMap = isNormalMap;
+            }
+        }
+    }
+}
+#endif

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 804e1ce4c496647cfa3f1a1134187c71
+timeCreated: 1516769271
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporterInspector.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporterInspector.cs
@@ -1,0 +1,49 @@
+#if UNITY_2017_1_OR_NEWER
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Experimental.AssetImporters;
+using UnityEngine;
+
+namespace UnityGLTF
+{
+    [CustomEditor(typeof(GLTFImporter))]
+    [CanEditMultipleObjects]
+    public class GLTFImporterInspector : AssetImporterEditor
+    {
+        private string[] _importNormalsNames;
+
+        public override void OnInspectorGUI()
+        {
+            if (_importNormalsNames == null)
+            {
+                _importNormalsNames = Enum.GetNames(typeof(GLTFImporterNormals))
+                    .Select(n => ObjectNames.NicifyVariableName(n))
+                    .ToArray();
+            }
+            EditorGUILayout.LabelField("Meshes", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_removeEmptyRootObjects"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_scaleFactor"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_maximumLod"), new GUIContent("Maximum LOD"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_readWriteEnabled"), new GUIContent("Read/Write Enabled"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_generateColliders"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_swapUvs"), new GUIContent("Swap UVs"));
+            EditorGUILayout.Separator();
+            EditorGUILayout.LabelField("Normals", EditorStyles.boldLabel);
+            EditorGUI.BeginChangeCheck();
+            var importNormalsProp = serializedObject.FindProperty("_importNormals");
+            var importNormals = EditorGUILayout.Popup(importNormalsProp.displayName, importNormalsProp.intValue, _importNormalsNames);
+            if (EditorGUI.EndChangeCheck())
+            {
+                importNormalsProp.intValue = importNormals;
+            }
+            EditorGUILayout.Separator();
+            EditorGUILayout.LabelField("Materials", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_importMaterials"));
+			EditorGUILayout.PropertyField(serializedObject.FindProperty("_useJpgTextures"), new GUIContent("Use JPG Textures"));
+
+            ApplyRevertGUI();
+        }
+    }
+}
+#endif

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporterInspector.cs.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporterInspector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 20d4d64afd8e74d39a8d8fad13d909fc
+timeCreated: 1508963536
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporterNormals.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporterNormals.cs
@@ -1,0 +1,11 @@
+#if UNITY_2017_1_OR_NEWER
+namespace UnityGLTF
+{
+    public enum GLTFImporterNormals
+    {
+        Import,
+        Calculate,
+        None
+    }
+}
+#endif

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporterNormals.cs.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporterNormals.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: f3961a7b54dd64330a1228d3aa9993c0
+timeCreated: 1519449419
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 
 namespace UnityGLTF
 {
-
 	/// <summary>
 	/// Component to load a GLTF scene with
 	/// </summary>
@@ -23,6 +22,12 @@ namespace UnityGLTF
 			FileStream gltfStream = null;
 			if (UseStream)
 			{
+				// Path.Combine treats paths that start with the separator character
+				// as absolute paths, ignoring the first path passed in. This removes
+				// that character to properly handle a filename written with it.
+				Url = Url.TrimStart(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar });
+
+
 				var fullPath = Path.Combine(Application.streamingAssetsPath, Url);
 				gltfStream = File.OpenRead(fullPath);
 				loader = new GLTFSceneImporter(
@@ -43,6 +48,7 @@ namespace UnityGLTF
 
             loader.MaximumLod = MaximumLod;
 			yield return loader.Load(-1, Multithreaded);
+
 			if (gltfStream != null)
 			{
 #if WINDOWS_UWP

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -101,6 +101,10 @@ namespace UnityGLTF
 				byte[] gltfData = www.downloadHandler.data;
 				_gltfStream.Stream = new MemoryStream(gltfData, 0, gltfData .Length, false, true);
 			}
+			else if (_loadType == LoadType.Stream)
+			{
+				// Do nothing, since the stream was passed in via the constructor.
+			}
 			else
 			{
 				throw new Exception("Invalid load type specified: " + _loadType);


### PR DESCRIPTION
(also see #131)

Adds a ScriptedImporter for Unity 2017.1 and up, with support for a lot of standard model importer options:

![image](https://user-images.githubusercontent.com/1100891/36626108-4620fd6a-18f2-11e8-83d9-24ca05c9b1af.png)


Everything is imported as it is at runtime (except the coroutine is run synchronously), then textures are encoded (as png or jpg), and references are re-linked to assets on disk.
 
Only .glb files are supported (Supporting .gltf would be tricky as we'd need to support importing the mesh data separately, as well as linking existing textures - it's also a bit awkward when compared to other Unity model assets).

Some things that are missing (nice-to-haves, really):

- Automatically switch previously imported textures when enabling/disabling "Use JPG textures" (maybe, I would hesitate to delete any files without user confirmation). Existing textures/materials _will_ automatically update with edits to the glTF file, however.
- Automatic tangent generation (though that might be out of scope/too complex right now, unfortunately Unity doesn't expose its tangent generation functionality last I checked)

Feedback is appreciated! Note that I included #115 here. Noticed quite a few pending changes on the loader side of things, but that was needed in order to load from a stream (rather than use unnecessary UnityWebRequests in the editor).
