### PR TITLE
Added a new project to compile GLTFSerialization for NetStandard 1.3 …

### DIFF
--- a/GLTFSerialization/GLTFSerialization.NetStd/GLTFSerialization.NetStd.csproj
+++ b/GLTFSerialization/GLTFSerialization.NetStd/GLTFSerialization.NetStd.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <Authors>Khronos Group</Authors>
+    <Copyright></Copyright>
+    <Description>C# glTF Serializer</Description>
+    <Company></Company>
+    <Product>GLTFSerialization</Product>
+    <PackageId>GLTFSerialization</PackageId>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PackageProjectUrl>https://github.com/KhronosGroup/UnityGLTF/blob/master/README.md</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/KhronosGroup/UnityGLTF/blob/master/LICENSE</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/KhronosGroup/UnityGLTF</RepositoryUrl>
+    <PackageIconUrl>https://github.com/KhronosGroup/glTF/blob/master/specification/figures/gltf.png</PackageIconUrl>
+    <PackageTags>glTF 3D C#</PackageTags>
+    <RootNamespace>GLTF</RootNamespace>
+    <Version>1.0.0-alpha</Version>
+  </PropertyGroup>
+
+  <ItemGroup>		
+    <Compile Include="..\GLTFSerialization\**\*.cs" Exclude="..\GLTFSerialization\Properties\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/GLTFSerialization/GLTFSerialization.sln
+++ b/GLTFSerialization/GLTFSerialization.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GLTFSerialization", "GLTFSerialization\GLTFSerialization.csproj", "{72AC331F-9810-4DE2-8EA3-84559A787218}"
 EndProject
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GLTFSerializationCLI", "GLT
 	ProjectSection(ProjectDependencies) = postProject
 		{72AC331F-9810-4DE2-8EA3-84559A787218} = {72AC331F-9810-4DE2-8EA3-84559A787218}
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GLTFSerialization.NetStd", "GLTFSerialization.NetStd\GLTFSerialization.NetStd.csproj", "{40DE16CE-0346-4514-B05B-FE51758F9E3E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -65,6 +67,14 @@ Global
 		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|x86.ActiveCfg = Release|Any CPU
 		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|x86.Build.0 = Release|Any CPU
+		{40DE16CE-0346-4514-B05B-FE51758F9E3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40DE16CE-0346-4514-B05B-FE51758F9E3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40DE16CE-0346-4514-B05B-FE51758F9E3E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{40DE16CE-0346-4514-B05B-FE51758F9E3E}.Debug|x86.Build.0 = Debug|Any CPU
+		{40DE16CE-0346-4514-B05B-FE51758F9E3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40DE16CE-0346-4514-B05B-FE51758F9E3E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40DE16CE-0346-4514-B05B-FE51758F9E3E}.Release|x86.ActiveCfg = Release|Any CPU
+		{40DE16CE-0346-4514-B05B-FE51758F9E3E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
+++ b/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
@@ -184,7 +184,7 @@ namespace GLTF
 			{
 				using (var memoryStream = attributeAccessor.Stream as System.IO.MemoryStream)
 				{
-					bufferViewCache = memoryStream.GetBuffer();
+					bufferViewCache = memoryStream.ToArray();
 					return totalOffset;
 				}
 			}


### PR DESCRIPTION
…and generate the associated nuget package.

Also, changed a MemoryStream method from GetBuffer() to ToArray();

The ToArray(); method does the same as GetBuffer() but it's available in more platforms.

@bghgary this is related to issue #135