### PR TITLE
Added camera export

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -97,7 +97,8 @@ namespace UnityGLTF
 			binFile.Close();
 #endif
 
-			foreach (var image in _images)
+            GL.sRGBWrite = true;
+            foreach (var image in _images)
 			{
 				Debug.Log(image.name);
 				var renderTexture = RenderTexture.GetTemporary(image.width, image.height);
@@ -108,7 +109,8 @@ namespace UnityGLTF
 				exportTexture.Apply();
 				File.WriteAllBytes(Path.Combine(path, image.name + ".png"), exportTexture.EncodeToPNG());
 			}
-		}
+            GL.sRGBWrite = true;
+        }
 
 		private SceneId ExportScene(string name, Transform[] rootObjTransforms)
 		{
@@ -439,10 +441,10 @@ namespace UnityGLTF
 			switch (materialObj.shader.name)
 			{
 				case "Standard":
-				case "GLTF/GLTFStandard":
-					material.PbrMetallicRoughness = ExportPBRMetallicRoughness(materialObj);
-					break;
-				case "GLTF/GLTFConstant":
+                case "GLTF/PbrMetallicRoughness":
+                    material.PbrMetallicRoughness = ExportPBRMetallicRoughness(materialObj);
+                    break;
+                case "GLTF/GLTFConstant":
 					material.CommonConstant = ExportCommonConstant(materialObj);
 					break;
 			}


### PR DESCRIPTION
Started to add the camera export feature.
I had a few questions though: for orthographic projection, what do we mean by the x and y magnifications? I am unsure how to map the Unity orthographicSize and Viewport settings for the camera to the xMag and yMag. Any thoughts?

In addition, Unity seems to add other options to the camera model: rendering depth, occlusion culling, clear flags, background, target display, etc.. Do we handle those in the Extra/Extensions, or do we just export what is required from the specs?

Thanks for reviewing this!