### PR TITLE
Added GLTF EditorWindow and settings for exporter

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFExportMenu.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFExportMenu.cs
@@ -1,16 +1,37 @@
 using System;
 using UnityEditor;
 using UnityGLTF;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 
-public class GLTFExportMenu
+public class GLTFExportMenu : EditorWindow
 {
-	public static string RetrieveTexturePath(UnityEngine.Texture texture)
-	{
-		return AssetDatabase.GetAssetPath (texture);
-	}
+    public static string RetrieveTexturePath(UnityEngine.Texture texture)
+    {
+        return AssetDatabase.GetAssetPath(texture);
+    }
 
-	[MenuItem("GLTF/Export Selected")]
+    [MenuItem("GLTF/Settings")]
+    static void Init()
+    {
+        GLTFExportMenu window = (GLTFExportMenu)EditorWindow.GetWindow(typeof(GLTFExportMenu), false, "GLTF Settings");
+        window.Show();
+    }
+
+    void OnGUI()
+    {
+        EditorGUILayout.LabelField("Exporter", EditorStyles.boldLabel);
+        GLTFSceneExporter.ExportFullPath = EditorGUILayout.Toggle("Export using original path", GLTFSceneExporter.ExportFullPath);
+        GLTFSceneExporter.ExportNames = EditorGUILayout.Toggle("Export names of nodes", GLTFSceneExporter.ExportNames);
+        GLTFSceneExporter.RequireExtensions= EditorGUILayout.Toggle("Require extensions", GLTFSceneExporter.RequireExtensions);
+        EditorGUILayout.Separator();
+        EditorGUILayout.LabelField("Importer", EditorStyles.boldLabel);
+        EditorGUILayout.Separator();
+        EditorGUILayout.HelpBox("UnityGLTF version 0.1", MessageType.Info);
+        EditorGUILayout.HelpBox("Supported extensions: KHR_material_pbrSpecularGlossiness, ExtTextureTransform", MessageType.Info);
+    }
+
+    [MenuItem("GLTF/Export Selected")]
 	static void ExportSelected()
 	{
 		string name;


### PR DESCRIPTION
Hi,

It would be nice to be able to customize certain behavior of the tool. An example is the export of textures/images. Recently this has been programmed to export using the full file path. However, depending on the pipeline it might not be as useful to do so (like in my case). To make it easier to customize the tool I added a settings tab, which contains some of the booleans and useful information. Will this be a nice contribution?

![settings](https://user-images.githubusercontent.com/6676026/38642479-804ec7b2-3dda-11e8-951d-9a8f88fb2e41.png)
