### PR TITLE
Added support for loading non-convex mesh colliders

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -29,7 +29,8 @@ namespace UnityGLTF
         {
             None,
             Box,
-            Mesh
+            Mesh,
+            MeshConvex
         }
 
         /// <summary>
@@ -1000,11 +1001,14 @@ namespace UnityGLTF
                         boxCollider.center = curMesh.bounds.center;
                         boxCollider.size = curMesh.bounds.size;
                         break;
-
                     case ColliderType.Mesh:
                         var meshCollider = primitiveObj.AddComponent<MeshCollider>();
                         meshCollider.sharedMesh = curMesh;
-                        meshCollider.convex = true;
+                        break;
+                    case ColliderType.MeshConvex:
+                        var meshConvexCollider = primitiveObj.AddComponent<MeshCollider>();
+                        meshConvexCollider.sharedMesh = curMesh;
+                        meshConvexCollider.convex = true;
                         break;
                 }
 


### PR DESCRIPTION
Convex mesh colliders are apocalyptically expensive to generate at runtime for ~2000 triangle meshes.  In my tests I was seeing ~600ms delays.  Provide an option for loading non-convex meshes for folks who only want ray intersection and don't care about collider-to-collider intersection.  

Not sure if the enum should be:

Mesh
MeshConvex

Or

Mesh
MeshNonConvex

Cheers