### PR TITLE
Updating /ShaderRetention/normal.jpg to be marked as a normal map

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Shaders/ShaderRetention/normal.jpg.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Shaders/ShaderRetention/normal.jpg.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: 9ae95f298490a7b4d816251d4e2555d7
-timeCreated: 1517615515
+timeCreated: 1526511850
 licenseType: Pro
 TextureImporter:
   fileIDToRecycleName: {}
@@ -8,7 +8,7 @@ TextureImporter:
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
-    sRGBTexture: 1
+    sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
@@ -44,7 +44,7 @@ TextureImporter:
   alphaUsage: 1
   alphaIsTransparency: 0
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 1
   textureShape: 1
   maxTextureSizeSet: 0
   compressionQualitySet: 0


### PR DESCRIPTION
Unity keeps asking to update this file, since it's not correctly tagged as a normal map.

![image](https://user-images.githubusercontent.com/3580640/40248144-c4996560-5a83-11e8-9d0a-052f029a3aa4.png)
