### PR TITLE
Update platform runner to compile on Unity 2018.1 and later

### DIFF
--- a/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/PlatformRunner/PlatformRunner.cs
+++ b/UnityGLTF/Assets/UnityTestTools/IntegrationTestsFramework/TestRunner/Editor/PlatformRunner/PlatformRunner.cs
@@ -90,7 +90,11 @@ namespace UnityTest.IntegrationTests
 
 			AssetDatabase.Refresh();
 
+#if UNITY_2018_1_OR_NEWER
+			if (result.summary.result != UnityEditor.Build.Reporting.BuildResult.Succeeded)
+#else
 			if (!string.IsNullOrEmpty(result))
+#endif
 			{
 				if (InternalEditorUtility.inBatchMode)
 					EditorApplication.Exit(Batch.returnCodeRunError);


### PR DESCRIPTION
`BuildPipeline.BuildPlayer` no longer returns a string, but rather returns a `Build.BuildReporting.BuildReport `instance.  Modified the test runner to use the result code from that for error handling on Unity 2018.1 and later.  It still uses the string return code for all previous versions.