### PR TITLE
Fix RefCountedCacheData memory leak

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/RefCountedCacheData.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/RefCountedCacheData.cs
@@ -16,10 +16,10 @@ namespace UnityGLTF.Cache
 		/// Ref count for this cache data.
 		/// </summary>
 		/// <remarks>
-		/// Initialized to 1, as we assume that when creating a new ref-counted cache data, a reference to it will be stored
-		/// by an instantiated GLTF object.
+		/// Initialized to 0. When assigning the cache data to an instantiated GLTF
+		/// object the count will increase.
 		/// </remarks>
-		private int _refCount = 1;
+		private int _refCount = 0;
 		private readonly object _refCountLock = new object();
 
 		/// <summary>


### PR DESCRIPTION
Fixes: #167

It seems like ref count in the RefCountCacheData class isn't working properly. When an object of this class is instantiated its ref count starts at 1, and when a new InstantiatedGLTFObject holds a reference to the cache data its ref count increases. The problem arrives in this method from the SceneImporter class:
```cs
private void InitializeGltfTopLevelObject()
{
	InstantiatedGLTFObject instantiatedGltfObject = CreatedObject.AddComponent<InstantiatedGLTFObject>();
	instantiatedGltfObject.CachedData = new RefCountedCacheData
	{
		MaterialCache = _assetCache.MaterialCache,
		MeshCache = _assetCache.MeshCache,
		TextureCache = _assetCache.TextureCache
	};
}
```

When creating the new RefCountedCacheData its ref count is 1, and when assigning it to the cached data of the instantiated gltf object its ref count goes up to two. If we destroy the object that holds this component from the scene later on, its ref count will decrease to 1 again and the textures, meshes and materials won't be destroyed, causing a memory leak. This can be quite noticeable when creating and destroying many objects at runtime.

Setting the ref count initially to 0 solves this issue.