### PR TITLE
Improving performance by adding multithreading support

### DIFF
--- a/GLTFSerialization/GLTFSerialization/GLTFParser.cs
+++ b/GLTFSerialization/GLTFSerialization/GLTFParser.cs
@@ -19,7 +19,7 @@ namespace GLTF
 			public uint FileLength { get; set; }
 		}
 		
-		public static GLTFRoot ParseJson(Stream stream, long startPosition = 0)
+		public static void ParseJson(Stream stream, ref GLTFRoot gltfRoot, long startPosition = 0)
 		{
 			stream.Position = startPosition;
 			// Check for binary format magic bytes
@@ -32,7 +32,7 @@ namespace GLTF
 				stream.Position = startPosition;
 			}
 
-			return GLTFRoot.Deserialize(new StreamReader(stream));
+			gltfRoot = GLTFRoot.Deserialize(new StreamReader(stream));
 		}
 		
 		// Moves stream position to binary chunk location

--- a/GLTFSerialization/GLTFSerializationCLI/Program.cs
+++ b/GLTFSerialization/GLTFSerializationCLI/Program.cs
@@ -35,7 +35,8 @@ namespace GLTFSerializationCLI
 				goto exit;
 			}
 			
-			GLTFRoot root = GLTFParser.ParseJson(stream);
+			GLTFRoot root = null;
+			GLTFParser.ParseJson(stream, ref root);
 			ExtTextureTransformExtension ext = (ExtTextureTransformExtension)
 				root.Materials[1].PbrMetallicRoughness.BaseColorTexture.Extensions["EXT_texture_transform"];
 			root.Serialize(Console.Out);

--- a/GLTFSerialization/Tests/GLTFSerializationTests/GLTFLoaderTest.cs
+++ b/GLTFSerialization/Tests/GLTFSerializationTests/GLTFLoaderTest.cs
@@ -24,7 +24,8 @@ namespace GLTFSerializationTests
 			FileStream gltfStream = File.OpenRead(GLTF_PATH);
 
 			GLTFRoot.RegisterExtension(new TestExtensionFactory());
-			GLTFRoot gltfRoot = GLTFParser.ParseJson(gltfStream);
+			GLTFRoot gltfRoot = null;
+			GLTFParser.ParseJson(gltfStream,ref gltfRoot);
 			GLTFJsonLoadTestHelper.TestGLTF(gltfRoot);
 		}
 
@@ -33,8 +34,9 @@ namespace GLTFSerializationTests
 		{
 			Assert.IsTrue(File.Exists(GLTF_PBR_SPECGLOSS_PATH));
 			FileStream gltfStream = File.OpenRead(GLTF_PBR_SPECGLOSS_PATH);
-			
-			GLTFRoot gltfRoot = GLTFParser.ParseJson(gltfStream);
+
+			GLTFRoot gltfRoot = null;
+			GLTFParser.ParseJson(gltfStream, ref gltfRoot);
 
 			Assert.IsNotNull(gltfRoot.ExtensionsUsed);
 			Assert.IsTrue(gltfRoot.ExtensionsUsed.Contains(KHR_materials_pbrSpecularGlossinessExtensionFactory.EXTENSION_NAME));
@@ -57,7 +59,8 @@ namespace GLTFSerializationTests
 		{
 			Assert.IsTrue(File.Exists(GLB_PATH));
 			FileStream gltfStream = File.OpenRead(GLB_PATH);
-			GLTFRoot gltfRoot = GLTFParser.ParseJson(gltfStream);
+			GLTFRoot gltfRoot =null;
+			GLTFParser.ParseJson(gltfStream, ref gltfRoot);
 			GLTFJsonLoadTestHelper.TestGLB(gltfRoot);
 		}
 	}

--- a/GLTFSerialization/Tests/GLTFSerializationTests/GLTFRootTests.cs
+++ b/GLTFSerialization/Tests/GLTFSerializationTests/GLTFRootTests.cs
@@ -28,7 +28,8 @@ namespace GLTFSerializationTests
 			writer.Flush();
 			stream.Position = 0;
 
-			_testRoot = GLTFParser.ParseJson(stream);
+			_testRoot = null;
+			GLTFParser.ParseJson(stream, ref _testRoot);
 
 		}
 

--- a/GLTFSerialization/Tests/GLTFSerializationTests/MergeNodesTest.cs
+++ b/GLTFSerialization/Tests/GLTFSerializationTests/MergeNodesTest.cs
@@ -19,10 +19,12 @@ namespace GLTFSerializationTests
 			Assert.IsTrue(File.Exists(GLTF_LANTERN_PATH));
 			
 			FileStream gltfBoomBoxStream = File.OpenRead(GLTF_BOOMBOX_PATH);
-			GLTFRoot boomBoxRoot = GLTFParser.ParseJson(gltfBoomBoxStream);
+			GLTFRoot boomBoxRoot = null;
+			GLTFParser.ParseJson(gltfBoomBoxStream, ref boomBoxRoot);
 
 			FileStream gltfLanternStream = File.OpenRead(GLTF_LANTERN_PATH);
-			GLTFRoot lanternRoot = GLTFParser.ParseJson(gltfLanternStream);
+			GLTFRoot lanternRoot = null;
+			GLTFParser.ParseJson(gltfLanternStream, ref lanternRoot);
 
 			GLTFRoot boomBoxCopy = new GLTFRoot(boomBoxRoot);
 

--- a/GLTFSerialization/Tests/GLTFSerializationUWPTests/GLTFUWPLoaderTest.cs
+++ b/GLTFSerialization/Tests/GLTFSerializationUWPTests/GLTFUWPLoaderTest.cs
@@ -24,7 +24,8 @@ namespace GLTFSerializerUWPTests
 			StorageFile sampleFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri(GLTF_PATH));
 
 			IRandomAccessStream gltfStream = await sampleFile.OpenAsync(FileAccessMode.Read);
-			GLTFRoot gltfRoot = GLTFParser.ParseJson(gltfStream.AsStream());
+			GLTFRoot gltfRoot = null;
+			GLTFParser.ParseJson(gltfStream.AsStream(), ref gltfRoot);
 			GLTFJsonLoadTestHelper.TestGLTF(gltfRoot);
 		}
 
@@ -36,7 +37,8 @@ namespace GLTFSerializerUWPTests
 
 
 			IRandomAccessStream gltfStream = await sampleFile.OpenAsync(FileAccessMode.Read);
-			GLTFRoot gltfRoot = GLTFParser.ParseJson(gltfStream.AsStreamForRead());
+			GLTFRoot gltfRoot = null;
+			GLTFParser.ParseJson(gltfStream.AsStreamForRead(), ref gltfRoot);
 
 			Assert.IsNotNull(gltfRoot.ExtensionsUsed);
 			Assert.IsTrue(gltfRoot.ExtensionsUsed.Contains(KHR_materials_pbrSpecularGlossinessExtensionFactory.EXTENSION_NAME));

--- a/UnityGLTF/Assets/UnityGLTF/Examples/RootMergeComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Examples/RootMergeComponent.cs
@@ -28,11 +28,13 @@ namespace UnityGLTF
 
 			yield return loader0.LoadStream(Path.GetFileName(asset0Path));
 			var asset0Stream = loader0.LoadedStream;
-			var asset0Root = GLTFParser.ParseJson(asset0Stream);
+			GLTFRoot asset0Root = null;
+			GLTFParser.ParseJson(asset0Stream, ref asset0Root);
 
 			yield return loader1.LoadStream(Path.GetFileName(asset1Path));
 			var asset1Stream = loader1.LoadedStream;
-			var asset1Root = GLTFParser.ParseJson(asset1Stream);
+			GLTFRoot asset1Root = null;
+			GLTFParser.ParseJson(asset0Stream, ref asset1Root);
 
 			string newPath = "../../" + URIHelper.GetDirectoryName(asset0Path);
 
@@ -70,8 +72,8 @@ namespace UnityGLTF
 				);
 
 			importer.MaximumLod = MaximumLod;
-
-			yield return importer.LoadScene(-1, Multithreaded);
+			importer.isMultithreaded = Multithreaded;
+			yield return importer.LoadScene(-1);
 		}
 #endif
 	}

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
@@ -336,14 +336,16 @@ namespace UnityGLTF
             ILoader fileLoader = new FileLoader(Path.GetDirectoryName(projectFilePath));
             using (var stream = File.OpenRead(projectFilePath))
             {
-                GLTFRoot gLTFRoot = GLTFParser.ParseJson(stream);
+	            GLTFRoot gLTFRoot = null;
+	            GLTFParser.ParseJson(stream, ref gLTFRoot);
                 var loader = new GLTFSceneImporter(gLTFRoot, fileLoader, stream);
 
                 loader.MaximumLod = _maximumLod;
+	            loader.isMultithreaded = true;
 
-                // HACK: Force the coroutine to run synchronously in the editor
-                var stack = new Stack<IEnumerator>();
-                stack.Push(loader.LoadScene(isMultithreaded: true));
+				// HACK: Force the coroutine to run synchronously in the editor
+				var stack = new Stack<IEnumerator>();
+                stack.Push(loader.LoadScene());
 
                 while (stack.Count > 0)
                 {

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -22,6 +22,7 @@ namespace UnityGLTF
 		private bool loadOnStart = true;
 
 		public int MaximumLod = 300;
+		public int Timeout = 8;
 		public GLTFSceneImporter.ColliderType Collider = GLTFSceneImporter.ColliderType.None;
 
 		[SerializeField]
@@ -69,8 +70,10 @@ namespace UnityGLTF
 				sceneImporter.SceneParent = gameObject.transform;
 				sceneImporter.Collider = Collider;
 				sceneImporter.MaximumLod = MaximumLod;
+				sceneImporter.Timeout = Timeout;
+				sceneImporter.isMultithreaded = Multithreaded;
 				sceneImporter.CustomShaderName = shaderOverride ? shaderOverride.name : null;
-				yield return sceneImporter.LoadScene(-1, Multithreaded);
+				yield return sceneImporter.LoadScene(-1);
 
 				// Override the shaders on all materials if a shader is provided
 				if (shaderOverride != null)

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Loader/FileLoader.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Loader/FileLoader.cs
@@ -15,9 +15,12 @@ namespace UnityGLTF.Loader
 		private string _rootDirectoryPath;
 		public Stream LoadedStream { get; private set; }
 
+		public bool HasSyncLoadMethod { get; private set; }
+
 		public FileLoader(string rootDirectoryPath)
 		{
 			_rootDirectoryPath = rootDirectoryPath;
+			HasSyncLoadMethod = true;
 		}
 
 		public IEnumerator LoadStream(string gltfFilePath)
@@ -41,5 +44,26 @@ namespace UnityGLTF.Loader
 			yield return null;
 			LoadedStream = File.OpenRead(pathToLoad);
 		}
+
+		public void LoadStreamSync(string gltfFilePath)
+ 	    {
+ 	        if (gltfFilePath == null)
+ 	        {
+ 	            throw new ArgumentNullException("gltfFilePath");
+ 	        }
+ 
+ 	        LoadFileStreamSync(_rootDirectoryPath, gltfFilePath);
+ 	    }
+ 
+ 	    private void LoadFileStreamSync(string rootPath, string fileToLoad)
+ 	    {
+ 	        string pathToLoad = Path.Combine(rootPath, fileToLoad);
+ 	        if (!File.Exists(pathToLoad))
+ 	        {
+ 	            throw new FileNotFoundException("Buffer file not found", fileToLoad);
+ 	        }
+ 
+ 	        LoadedStream = File.OpenRead(pathToLoad);
+ 	    }
 	}
 }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Loader/ILoader.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Loader/ILoader.cs
@@ -12,6 +12,10 @@ namespace UnityGLTF.Loader
 	{
 		IEnumerator LoadStream(string relativeFilePath);
 
+		void LoadStreamSync(string jsonFilePath);
+
 		Stream LoadedStream { get; }
+
+		bool HasSyncLoadMethod { get; }
 	}
 }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Loader/WebRequestLoader.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Loader/WebRequestLoader.cs
@@ -17,11 +17,14 @@ namespace UnityGLTF.Loader
 	{
 		public Stream LoadedStream { get; private set; }
 
+		public bool HasSyncLoadMethod { get; private set; }
+
 		private string _rootURI;
 
 		public WebRequestLoader(string rootURI)
 		{
 			_rootURI = rootURI;
+			HasSyncLoadMethod = false;
 		}
 
 		public IEnumerator LoadStream(string gltfFilePath)
@@ -32,6 +35,11 @@ namespace UnityGLTF.Loader
 			}
 
 			yield return CreateHTTPRequest(_rootURI, gltfFilePath);
+		}
+
+		public void LoadStreamSync(string jsonFilePath)
+		{
+			throw new NotImplementedException();
 		}
 
 		private IEnumerator CreateHTTPRequest(string rootUri, string httpRequestPath)

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Editor/GLTFBenchmark.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Editor/GLTFBenchmark.cs
@@ -6,6 +6,7 @@ using UnityEngine.Networking;
 using System.Text;
 using System.IO;
 using GLTF;
+using GLTF.Schema;
 
 public class GLTFBenchmark : MonoBehaviour
 {
@@ -43,7 +44,8 @@ public class GLTFBenchmark : MonoBehaviour
 			for (var i = 0; i < NumberOfIterations; i++)
 			{
 				timer.Start();
-				GLTFParser.ParseJson(new MemoryStream(www.downloadHandler.data));
+				GLTFRoot gltfRoot = null;
+				GLTFParser.ParseJson(new MemoryStream(www.downloadHandler.data), ref gltfRoot);
 				timer.Stop();
 
 				Debug.LogFormat("Iteration {0} took: {1}ms", i, timer.ElapsedMilliseconds);

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Integration/GLTFTestComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Integration/GLTFTestComponent.cs
@@ -20,7 +20,8 @@ namespace UnityGLTF.Tests.Integration
 				);
 
 			sceneImporter.SceneParent = gameObject.transform;
-			yield return sceneImporter.LoadScene(-1, Multithreaded);
+			sceneImporter.isMultithreaded = Multithreaded;
+			yield return sceneImporter.LoadScene(-1);
 			IntegrationTest.Pass();
 		}
 	}


### PR DESCRIPTION
Hi there,

As some of you may have experienced, currently the UnityGLTF library blocks the main thread when importing models containing complex geometry and/or textures. Although the coroutine approach is used in the project, sometimes multithreading may be a better solution as it provides a **non-blocking behavior as well as better performance (in some situations)**. 

**Implementation**
I noticed a parameter `isMultithreaded` in `GLTFSceneImporter.LoadScene` that is never actually used, changed it to a public field and used it as the switch. I put some presumably time-consuming work on other threads (rather than the main thread), which includes `LoadStream`, `ParseJson`, `stream.Read`, `buildMeshAttributesThread`, and `GLTFHelpers.BuildMeshAttributes`. 

I have to change the `ILoader` interface to add support for non-coroutine based `LoadStreamSync` method, as coroutine methods cannot be easily executed on threads and doesn't really make sense for created threads anyway. I also have to change the signature of `ParseJson` in `GLTFParser.cs` to make it thread-friendly.

**Performance**
HUGE frame rate increase for certain models containing complex geometry and/or textures. I observed up to 200% fps increase for [this model](https://sketchfab.com/models/9736bfd2df1444cdab54adfc04c6a659) on a Windows desktop computer. In general, it should increase your fps and/or decrease the main thread freezing time. It should not make any tangible negative impact to the loading time, if no faster loading is observed.

**Limitations**
As mentioned in #9, `Texture2D.LoadImage` is slow and there's no obvious way around it. Same with `Texture2D.Apply`.

**Unity Job System?**
The recently introduced Unity Job System seems good, but currently it is still limited in a number of ways. Also, I don't believe it is very backward compatible.

Reference: #216 