### PR TITLE
VS solution for building DLL from UnityGLTF sources

### DIFF
--- a/UnityGLTF/.gitignore
+++ b/UnityGLTF/.gitignore
@@ -29,6 +29,9 @@ ExportedObj/
 *.svd
 *.pdb
 
+!*-dll.csproj
+!*-dll.sln
+
 # Unity3D generated meta files
 *.pidb.meta
 

--- a/UnityGLTF/UnityGLTF-dll.csproj
+++ b/UnityGLTF/UnityGLTF-dll.csproj
@@ -1,0 +1,80 @@
+﻿<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F7C86AC9-627D-4D15-BC95-9E4571B83878}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <NoStandardLibraries>false</NoStandardLibraries>
+    <AssemblyName>ClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>UnityGLTF_dll</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="GLTFSerialization">
+      <HintPath>..\GLTFSerialization\GLTFSerialization\obj\Release\GLTFSerialization.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="UnityEngine">
+      <HintPath>C:\Program Files\Unity_2018.1.2f1\Editor\Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Assets\UnityGLTF\Scripts\Async\AsyncAction.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Async\TaskExtensions.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Cache\AnimationCacheData.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Cache\AssetCache.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Cache\BufferCacheData.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Cache\MaterialCacheData.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Cache\MeshCacheData.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Cache\RefCountedCacheData.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Cache\TextureCacheData.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Exceptions.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Extensions\SchemaExtensions.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\GLTFComponent.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\GLTFSceneExporter.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\GLTFSceneImporter.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\InstantiatedGLTFObject.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Loader\FileLoader.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Loader\ILoader.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Loader\StorageFolderLoader.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Loader\WebRequestLoader.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\UniformMaps\MetalRough2StandardMap.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\UniformMaps\MetalRoughMap.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\UniformMaps\SpecGloss2StandardMap.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\UniformMaps\SpecGlossMap.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\UniformMaps\StandardMap.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\UniformMaps\UniformMap.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\URIHelper.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSHARP.Targets" />
+  <ProjectExtensions>
+    <VisualStudio AllowExistingFolder="true" />
+  </ProjectExtensions>
+</Project>

--- a/UnityGLTF/UnityGLTF-dll.csproj
+++ b/UnityGLTF/UnityGLTF-dll.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{F7C86AC9-627D-4D15-BC95-9E4571B83878}</ProjectGuid>
     <OutputType>Library</OutputType>
     <NoStandardLibraries>false</NoStandardLibraries>
-    <AssemblyName>ClassLibrary</AssemblyName>
+    <AssemblyName>UnityGLTF</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -27,12 +27,19 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <RootNamespace>UnityGLTF_dll</RootNamespace>
+    <RootNamespace>UnityGLTF</RootNamespace>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)' == 'Release' ">
     <Reference Include="GLTFSerialization">
       <HintPath>..\GLTFSerialization\GLTFSerialization\obj\Release\GLTFSerialization.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <Reference Include="GLTFSerialization">
+      <HintPath>..\GLTFSerialization\GLTFSerialization\obj\Debug\GLTFSerialization.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -41,6 +48,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UnityEngine">
+      <HintPath>C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>C:\Program Files\Unity\Hub\Editor\Data\Managed\UnityEngine.dll</HintPath>
       <HintPath>C:\Program Files\Unity_2018.1.2f1\Editor\Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/UnityGLTF/UnityGLTF-dll.csproj
+++ b/UnityGLTF/UnityGLTF-dll.csproj
@@ -48,9 +48,9 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UnityEngine">
-      <HintPath>C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll</HintPath>
-      <HintPath>C:\Program Files\Unity\Hub\Editor\Data\Managed\UnityEngine.dll</HintPath>
-      <HintPath>C:\Program Files\Unity_2018.1.2f1\Editor\Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath Condition="Exists('C:\Program Files\Unity\Editor\Data\Managed')">C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath Condition="Exists('C:\Program Files\Unity\Hub\Editor\Data\Managed')">C:\Program Files\Unity\Hub\Editor\Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath Condition="Exists('C:\Program Files\Unity_2018.1.2f1\Editor\Data\Managed')">C:\Program Files\Unity_2018.1.2f1\Editor\Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/UnityGLTF/UnityGLTF-dll.csproj
+++ b/UnityGLTF/UnityGLTF-dll.csproj
@@ -29,17 +29,16 @@
   <PropertyGroup>
     <RootNamespace>UnityGLTF</RootNamespace>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(Configuration)' == 'Release' ">
-    <Reference Include="GLTFSerialization">
-      <HintPath>..\GLTFSerialization\GLTFSerialization\obj\Release\GLTFSerialization.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
     <Reference Include="GLTFSerialization">
       <HintPath>..\GLTFSerialization\GLTFSerialization\obj\Debug\GLTFSerialization.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="GLTFSerialization, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>Assets\UnityGLTF\Plugins\GLTFSerialization.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/UnityGLTF/UnityGLTF-dll.sln
+++ b/UnityGLTF/UnityGLTF-dll.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2003
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnityGLTF-dll", "UnityGLTF-dll.csproj", "{F7C86AC9-627D-4D15-BC95-9E4571B83878}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F7C86AC9-627D-4D15-BC95-9E4571B83878}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7C86AC9-627D-4D15-BC95-9E4571B83878}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7C86AC9-627D-4D15-BC95-9E4571B83878}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7C86AC9-627D-4D15-BC95-9E4571B83878}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D5E897F1-2E7A-4F91-A5E3-8A55517B7263}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
A Unity project is not a particularly useful delivery format for what is ultimately a library for other applications to consume. This PR adds `UnityGLTF/UnityGLTF-dll.csproj`, which describes all the same scripts as the Unity project, but packages them as a DLL (with dependencies on GLTFSerialization.dll and UnityEngine.dll). Note that this project excludes the Tests folder and anything else with UnityEditor dependencies.