### PR TITLE
Fix for roughness factor issue #251

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/MetalRoughMap.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/MetalRoughMap.cs
@@ -57,5 +57,15 @@ namespace UnityGLTF
 			base.Copy(copy);
 			return copy;
 		}
+		
+		public override double RoughnessFactor
+		{
+			get { 
+				return _material.GetFloat("_Glossiness");
+			}
+			set { 
+				_material.SetFloat("_Glossiness", (float)value);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Proposed fix for issue #251.

**Explanation:** 
In the base class [MetalRough2StandardMap](https://github.com/KhronosGroup/UnityGLTF/blob/master/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/MetalRough2StandardMap.cs) RoughnessFactor is statically set to 0.5 since the standard shader does not support this parameter:
```
// not supported by the Standard shader
public virtual double RoughnessFactor
{
	get { return 0.5; }
	set { return; 
}
```
 The inherited class [MetalRoughMap](https://github.com/KhronosGroup/UnityGLTF/blob/master/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/MetalRoughMap.cs) does not override this, so we have the same behavior here, i.e. the original RoughnessFactor that was set in the gltf file gets lost.

However, in class [MetalRoughMap](https://github.com/KhronosGroup/UnityGLTF/blob/master/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/MetalRoughMap.cs) the default shader is PbrMetallicRoughness. When looking at line 12 in [PbrMetallicRoughness.shader](https://github.com/KhronosGroup/UnityGLTF/blob/master/UnityGLTF/Assets/UnityGLTF/Shaders/PbrMetallicRoughness.shader)  we can see the following:

`_Glossiness("Roughness Factor", Range(0.0, 1.0)) = 1.0`

This means that
1. Glossiness/Roughness Factor is supported by this shader
2. The default value is 1.0

I guess this is the reason why we always get 1.0 in the end, not 0.5 (see description of issue #251).

In my opinion this issue can be resolved by overriding RoughnessFactor in class MetalRoughMap as proposed in this pull request.

However, I'm not sure if we would have to deal with the case that a shader is used which does not support the property (PbrMetallicRoughness is the default shader, but other shaders can be specified through other constructors).