### PR TITLE
Fixed issue where edit time import no longer worked

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -405,8 +405,16 @@ namespace UnityGLTF
 			}
 
 			Node nodeToLoad = _gltfRoot.Nodes[nodeIndex];
-			await Task.Run(() => ConstructBufferData(nodeToLoad));
-			
+
+			if (Application.isEditor)
+			{
+				ConstructBufferData(nodeToLoad);
+			}
+			else
+			{
+				await Task.Run(() => ConstructBufferData(nodeToLoad));
+			}
+
 			await ConstructNode(nodeToLoad, nodeIndex);
 		}
 


### PR DESCRIPTION
fixed issue where edit time import no longer worked due to Task.RunTask() not properly returning and continuing execution from called function