### PR TITLE
switch to new style project for CLI csproj

### DIFF
--- a/GLTFSerialization/GLTFSerialization.sln
+++ b/GLTFSerialization/GLTFSerialization.sln
@@ -3,16 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GLTFSerialization", "GLTFSerialization\GLTFSerialization.csproj", "{72AC331F-9810-4DE2-8EA3-84559A787218}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GLTFSerializationCLI", "GLTFSerializationCLI\GLTFSerializationCLI.csproj", "{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}"
-	ProjectSection(ProjectDependencies) = postProject
-		{72AC331F-9810-4DE2-8EA3-84559A787218} = {72AC331F-9810-4DE2-8EA3-84559A787218}
-	EndProjectSection
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GLTFSerialization", "GLTFSerialization\GLTFSerialization.csproj", "{72AC331F-9810-4DE2-8EA3-84559A787218}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GLTFSerializationTests", "Tests\GLTFSerializationTests\GLTFSerializationTests.csproj", "{821B87A3-D8FA-407A-BC58-928A859C71C4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GLTFSerializationUWPTests", "Tests\GLTFSerializationUWPTests\GLTFSerializationUWPTests.csproj", "{EAD1EF7E-A898-4741-9DF5-269A33E6F875}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GLTFSerializationCLI", "GLTFSerializationCLI\GLTFSerializationCLI.csproj", "{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -42,22 +39,6 @@ Global
 		{72AC331F-9810-4DE2-8EA3-84559A787218}.Release|x64.Build.0 = Release|Any CPU
 		{72AC331F-9810-4DE2-8EA3-84559A787218}.Release|x86.ActiveCfg = Release|Any CPU
 		{72AC331F-9810-4DE2-8EA3-84559A787218}.Release|x86.Build.0 = Release|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Debug|ARM.Build.0 = Debug|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Debug|x64.Build.0 = Debug|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Debug|x86.Build.0 = Debug|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|ARM.ActiveCfg = Release|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|ARM.Build.0 = Release|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|x64.ActiveCfg = Release|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|x64.Build.0 = Release|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|x86.ActiveCfg = Release|Any CPU
-		{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}.Release|x86.Build.0 = Release|Any CPU
 		{821B87A3-D8FA-407A-BC58-928A859C71C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{821B87A3-D8FA-407A-BC58-928A859C71C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{821B87A3-D8FA-407A-BC58-928A859C71C4}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -98,6 +79,22 @@ Global
 		{EAD1EF7E-A898-4741-9DF5-269A33E6F875}.Release|x86.ActiveCfg = Release|x86
 		{EAD1EF7E-A898-4741-9DF5-269A33E6F875}.Release|x86.Build.0 = Release|x86
 		{EAD1EF7E-A898-4741-9DF5-269A33E6F875}.Release|x86.Deploy.0 = Release|x86
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Debug|ARM.Build.0 = Debug|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Debug|x86.Build.0 = Debug|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Release|ARM.ActiveCfg = Release|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Release|ARM.Build.0 = Release|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Release|x64.Build.0 = Release|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Release|x86.ActiveCfg = Release|Any CPU
+		{3C8EFD3C-66B2-4D83-9DD2-E6A4C4D3F64C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GLTFSerialization/GLTFSerialization/GLTFSerialization.csproj
+++ b/GLTFSerialization/GLTFSerialization/GLTFSerialization.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>GLTF</RootNamespace>
     <AssemblyName>GLTFSerialization</AssemblyName>
     <StartupObject />
-    
-    <TargetFrameworks>netstandard1.3;net35</TargetFrameworks>
+
+    <TargetFrameworks>net35;netstandard1.3</TargetFrameworks>
     <TargetFrameworks Condition="'$(MSBuildRuntimeType)' != 'Mono'">$(TargetFrameworks);uap10.0.10586</TargetFrameworks>
-    
+
     <OutputType>Library</OutputType>
-    
+
     <Authors>Khronos Group</Authors>
     <Copyright></Copyright>
     <Description>C# glTF Serializer</Description>
@@ -23,17 +23,17 @@
     <PackageTags>glTF 3D C#</PackageTags>
     <RootNamespace>GLTF</RootNamespace>
     <Version>1.0.0-alpha</Version>
-    
+
     <IsUAPTargetFramework Condition="$(TargetFramework.ToLower().StartsWith('uap10.0'))">true</IsUAPTargetFramework>
     <IsNETStandardTargetFramework Condition="$(TargetFramework.ToLower().StartsWith('netstandard'))">true</IsNETStandardTargetFramework>
     <IsNETTargetFramework Condition="'$(IsNETStandardTargetFramework)' != 'true' and $(TargetFramework.ToLower().StartsWith('net'))">true</IsNETTargetFramework>
-    
+
     <ErrorReport>prompt</ErrorReport>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Prefer32Bit>false</Prefer32Bit>
-    
+
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
@@ -46,7 +46,7 @@
     <Optimize>true</Optimize>
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
-  
+
   <Choose>
     <When Condition="'$(IsUAPTargetFramework)' == 'true'">
       <PropertyGroup>
@@ -78,13 +78,13 @@
       </ItemGroup>
     </When>
   </Choose>
-  
+
   <PropertyGroup Condition="'$(Platform)' == 'AnyCPU'">
     <OutputPath>..\..\UnityGLTF\Assets\UnityGLTF\Plugins\</OutputPath>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
-    <OutputPath>bin\x86\Debug\</OutputPath>
+    <OutputPath>bin\x86\$(Configuration)\</OutputPath>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>

--- a/GLTFSerialization/GLTFSerializationCLI/GLTFSerializationCLI.csproj
+++ b/GLTFSerialization/GLTFSerializationCLI/GLTFSerializationCLI.csproj
@@ -1,37 +1,35 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6D33A58F-E6C8-4BA4-9420-DFF2AFC8D813}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <RootNamespace>GLTFSerializationCLI</RootNamespace>
     <AssemblyName>GLTFSerializationCLI</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <OutputType>Exe</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+
+    <TargetFrameworks>net461</TargetFrameworks>
+
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
   <ItemGroup>
+    <ProjectReference Include="..\GLTFSerialization\GLTFSerialization.csproj" />
+
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -41,18 +39,5 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GLTFSerialization\GLTFSerialization.csproj">
-      <Project>{72ac331f-9810-4de2-8ea3-84559a787218}</Project>
-      <Name>GLTFSerialization</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>


### PR DESCRIPTION
this isn't strictly necessary as it only has one target, but it seems to work better with the GLTFSerialization project with the new style csproj