### PR TITLE
Upgrades netcore package to 6.1.9

### DIFF
--- a/GLTFSerialization/GLTFSerialization/GLTFSerialization.csproj
+++ b/GLTFSerialization/GLTFSerialization/GLTFSerialization.csproj
@@ -59,7 +59,7 @@
       </PropertyGroup>
       <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-        <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="5.2.3" />
+        <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
       </ItemGroup>
     </When>
     <When Condition="'$(IsNETTargetFramework)' == 'true'">

--- a/GLTFSerialization/Tests/GLTFSerializationUWPTests/GLTFSerializationUWPTests.csproj
+++ b/GLTFSerialization/Tests/GLTFSerializationUWPTests/GLTFSerializationUWPTests.csproj
@@ -166,7 +166,7 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="5.2.3" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />


### PR DESCRIPTION
As stated, upgrades the Microsoft.NETCore.UniversalWindowsPlatform to 6.1.9. Which will only happen when platform targets uap.