### PR TITLE
Update dll project to track latest UnityGLTF updates

### DIFF
--- a/UnityGLTF/UnityGLTF-dll.csproj
+++ b/UnityGLTF/UnityGLTF-dll.csproj
@@ -6,7 +6,7 @@
     <OutputType>Library</OutputType>
     <NoStandardLibraries>false</NoStandardLibraries>
     <AssemblyName>UnityGLTF</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;UNITY_2017_1_OR_NEWER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -29,15 +29,10 @@
   <PropertyGroup>
     <RootNamespace>UnityGLTF</RootNamespace>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <Reference Include="GLTFSerialization">
-      <HintPath>..\GLTFSerialization\GLTFSerialization\obj\Debug\GLTFSerialization.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
     <Reference Include="GLTFSerialization, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>Assets\UnityGLTF\Plugins\GLTFSerialization.dll</HintPath>
+      <HintPath>Assets\UnityGLTF\Plugins\net35\GLTFSerialization.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
@@ -53,7 +48,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Assets\UnityGLTF\Scripts\Async\AsyncAction.cs" />
+    <Compile Include="Assets\UnityGLTF\Scripts\Async\AsyncCoroutineHelper.cs" />
     <Compile Include="Assets\UnityGLTF\Scripts\Async\TaskExtensions.cs" />
     <Compile Include="Assets\UnityGLTF\Scripts\Cache\AnimationCacheData.cs" />
     <Compile Include="Assets\UnityGLTF\Scripts\Cache\AssetCache.cs" />

--- a/UnityGLTF/UnityGLTF-dll.csproj
+++ b/UnityGLTF/UnityGLTF-dll.csproj
@@ -22,7 +22,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;UNITY_2017_1_OR_NEWER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
The csproj that generates a UnityGLTF DLL was not updated for the 2017.4 shift. This PR updates the target framework, and relinks some paths.