### PR TITLE
Remove debug logs that throw in il2cpp

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
@@ -94,6 +94,7 @@ namespace GLTF.Extensions
 				{
 					throw new Exception("JToken used for Texture deserialization was not a JObject. It was a " + token.Type.ToString());
 				}
+				// Broken on il2cpp. Uncomment for Windows targets
 				//System.Diagnostics.Debug.WriteLine("textureObject is " + textureObject.Type + " with a value of: " + textureObject[TextureInfo.INDEX].Type + " " + textureObject.ToString());
 
 				int indexVal = textureObject[TextureInfo.INDEX].DeserializeAsInt();

--- a/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
@@ -94,7 +94,7 @@ namespace GLTF.Extensions
 				{
 					throw new Exception("JToken used for Texture deserialization was not a JObject. It was a " + token.Type.ToString());
 				}
-				System.Diagnostics.Debug.WriteLine("textureObject is " + textureObject.Type + " with a value of: " + textureObject[TextureInfo.INDEX].Type + " " + textureObject.ToString());
+				//System.Diagnostics.Debug.WriteLine("textureObject is " + textureObject.Type + " with a value of: " + textureObject[TextureInfo.INDEX].Type + " " + textureObject.ToString());
 
 				int indexVal = textureObject[TextureInfo.INDEX].DeserializeAsInt();
 				textureInfo = new TextureInfo()

--- a/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
@@ -94,8 +94,11 @@ namespace GLTF.Extensions
 				{
 					throw new Exception("JToken used for Texture deserialization was not a JObject. It was a " + token.Type.ToString());
 				}
-				// Broken on il2cpp. Uncomment for Windows targets
-				//System.Diagnostics.Debug.WriteLine("textureObject is " + textureObject.Type + " with a value of: " + textureObject[TextureInfo.INDEX].Type + " " + textureObject.ToString());
+
+#if DEBUG
+				// Broken on il2cpp. Don't ship debug DLLs there.
+				System.Diagnostics.Debug.WriteLine("textureObject is " + textureObject.Type + " with a value of: " + textureObject[TextureInfo.INDEX].Type + " " + textureObject.ToString());
+#endif
 
 				int indexVal = textureObject[TextureInfo.INDEX].DeserializeAsInt();
 				textureInfo = new TextureInfo()

--- a/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_pbrSpecularGlossinessExtensionFactory.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_pbrSpecularGlossinessExtensionFactory.cs
@@ -30,6 +30,7 @@ namespace GLTF.Schema
 
 			if (extensionToken != null)
 			{
+				// Broken on il2cpp. Uncomment for Windows targets
 				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
 				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
 

--- a/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_pbrSpecularGlossinessExtensionFactory.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_pbrSpecularGlossinessExtensionFactory.cs
@@ -30,8 +30,8 @@ namespace GLTF.Schema
 
 			if (extensionToken != null)
 			{
-				System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
-				System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
+				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
+				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
 
 				JToken diffuseFactorToken = extensionToken.Value[DIFFUSE_FACTOR];
 				diffuseFactor = diffuseFactorToken != null ? diffuseFactorToken.DeserializeAsColor() : diffuseFactor;

--- a/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_pbrSpecularGlossinessExtensionFactory.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_pbrSpecularGlossinessExtensionFactory.cs
@@ -30,10 +30,11 @@ namespace GLTF.Schema
 
 			if (extensionToken != null)
 			{
-				// Broken on il2cpp. Uncomment for Windows targets
-				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
-				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
-
+#if DEBUG
+				// Broken on il2cpp. Don't ship debug DLLs there.
+				System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
+				System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
+#endif
 				JToken diffuseFactorToken = extensionToken.Value[DIFFUSE_FACTOR];
 				diffuseFactor = diffuseFactorToken != null ? diffuseFactorToken.DeserializeAsColor() : diffuseFactor;
 				diffuseTextureInfo = extensionToken.Value[DIFFUSE_TEXTURE].DeserializeAsTexture(root);

--- a/GLTFSerialization/GLTFSerialization/Extensions/MSFT_LODExtensionFactory.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/MSFT_LODExtensionFactory.cs
@@ -24,6 +24,7 @@ namespace GLTF.Schema
 			List<int> meshIds = new List<int>();
 			if (extensionToken != null)
 			{
+				// Broken on il2cpp. Uncomment for Windows targets
 				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
 				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
 

--- a/GLTFSerialization/GLTFSerialization/Extensions/MSFT_LODExtensionFactory.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/MSFT_LODExtensionFactory.cs
@@ -24,8 +24,8 @@ namespace GLTF.Schema
 			List<int> meshIds = new List<int>();
 			if (extensionToken != null)
 			{
-				System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
-				System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
+				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
+				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
 
 				JToken meshIdsToken = extensionToken.Value[IDS];
 				meshIds = meshIdsToken.CreateReader().ReadInt32List();

--- a/GLTFSerialization/GLTFSerialization/Extensions/MSFT_LODExtensionFactory.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/MSFT_LODExtensionFactory.cs
@@ -24,10 +24,11 @@ namespace GLTF.Schema
 			List<int> meshIds = new List<int>();
 			if (extensionToken != null)
 			{
-				// Broken on il2cpp. Uncomment for Windows targets
-				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
-				//System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
-
+#if DEBUG
+				// Broken on il2cpp. Don't ship debug DLLs there.
+				System.Diagnostics.Debug.WriteLine(extensionToken.Value.ToString());
+				System.Diagnostics.Debug.WriteLine(extensionToken.Value.Type);
+#endif
 				JToken meshIdsToken = extensionToken.Value[IDS];
 				meshIds = meshIdsToken.CreateReader().ReadInt32List();
 			}


### PR DESCRIPTION
Workaround for https://issuetracker.unity3d.com/issues/uwp-il2cpp-assertion-error-being-triggered-on-calling-debug-dot-writeline