### PR TITLE
Add error handling to scene loading, refactor WebRequestLoader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ artifacts/
 *.pdb
 *.pgc
 *.pgd
-*.rsp
 *.sbr
 *.tlb
 *.tli

--- a/UnityGLTF/Assets/UnityGLTF/Examples/MultiSceneComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Examples/MultiSceneComponent.cs
@@ -21,7 +21,7 @@ namespace UnityGLTF.Examples
 			_asyncCoroutineHelper = gameObject.AddComponent<AsyncCoroutineHelper>();
 			Uri uri = new Uri(Url);
 			var directoryPath = URIHelper.AbsoluteUriPath(uri);
-			_loader = new WebRequestLoader(directoryPath, _asyncCoroutineHelper);
+			_loader = new WebRequestLoader(directoryPath);
 			_fileName = URIHelper.GetFileFromUri(uri);
 
 			LoadScene(SceneIndex);

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -64,7 +64,7 @@ namespace UnityGLTF
 				else
 				{
 					string directoryPath = URIHelper.GetDirectoryName(GLTFUri);
-					loader = new WebRequestLoader(directoryPath, asyncCoroutineHelper);
+					loader = new WebRequestLoader(directoryPath);
 
 					sceneImporter = new GLTFSceneImporter(
 						URIHelper.GetFileFromUri(new Uri(GLTFUri)),
@@ -81,7 +81,15 @@ namespace UnityGLTF
 				sceneImporter.isMultithreaded = Multithreaded;
 				sceneImporter.CustomShaderName = shaderOverride ? shaderOverride.name : null;
 
-				await sceneImporter.LoadSceneAsync(-1);
+				try
+				{
+					await sceneImporter.LoadSceneAsync(-1);
+				}
+				catch (Exception e)
+				{
+					Debug.LogError("Exception while loading:");
+					Debug.LogException(e);
+				}
 
 				// Override the shaders on all materials if a shader is provided
 				if (shaderOverride != null)

--- a/UnityGLTF/Assets/mcs.rsp
+++ b/UnityGLTF/Assets/mcs.rsp
@@ -1,0 +1,1 @@
+-r:System.Net.Http.dll

--- a/UnityGLTF/Assets/mcs.rsp.meta
+++ b/UnityGLTF/Assets/mcs.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2b9bbe579380e1b4d9cfb38838d4f9ab
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGLTF/UnityGLTF-dll.csproj
+++ b/UnityGLTF/UnityGLTF-dll.csproj
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;UNITY_2017_1_OR_NEWER</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;UNITY_2017_1_OR_NEWER,UNITY_2017_2_OR_NEWER,UNITY_2017_3_OR_NEWER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -22,7 +22,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;UNITY_2017_1_OR_NEWER</DefineConstants>
+    <DefineConstants>TRACE;UNITY_2017_1_OR_NEWER,UNITY_2017_2_OR_NEWER,UNITY_2017_3_OR_NEWER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -39,6 +39,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UnityEngine">


### PR DESCRIPTION
This PR adds an exception argument to the LoadScene callbacks, which are invoked even if the load/parse/import process fails.

It also refactors WebRequestLoader to use System.Net.Http instead of UnityWebRequest. This way we don't have to convert to and from Coroutines, but run directly with Tasks. It has the added benefit of playing better with the above exception handling system.