### PR TITLE
Load as initially visible (active) option

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -81,7 +81,7 @@ namespace UnityGLTF
 				sceneImporter.isMultithreaded = Multithreaded;
 				sceneImporter.CustomShaderName = shaderOverride ? shaderOverride.name : null;
 
-				await sceneImporter.LoadSceneAsync(-1);
+				await sceneImporter.LoadSceneAsync();
 
 				// Override the shaders on all materials if a shader is provided
 				if (shaderOverride != null)


### PR DESCRIPTION
Add an option to allow the user to specify whether the loaded object should be initially visible (active) or not