### PR TITLE
Preserve asset cache between loads

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Examples/SimpleWebServer.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Examples/SimpleWebServer.cs
@@ -193,7 +193,7 @@ new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
 
 				try
 				{
-					Stream input = File.OpenRead(filename); //new FileStream(filename, FileMode.Open);
+					Stream input = File.OpenRead(filename);
 					
 					//Adding permanent http response headers
 					string mime;

--- a/UnityGLTF/Assets/UnityGLTF/Examples/SimpleWebServer.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Examples/SimpleWebServer.cs
@@ -1,5 +1,5 @@
 ﻿// MIT License - Copyright (c) 2016 Can Güney Aksakalli
-
+using UnityEngine;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -187,13 +187,14 @@ new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
 			}
 
 			filename = Path.Combine(_rootDirectory, filename);
-
 			if (File.Exists(filename))
 			{
+				context.Response.StatusCode = (int)HttpStatusCode.OK;
+
 				try
 				{
-					Stream input = new FileStream(filename, FileMode.Open);
-
+					Stream input = File.OpenRead(filename); //new FileStream(filename, FileMode.Open);
+					
 					//Adding permanent http response headers
 					string mime;
 					context.Response.ContentType = _mimeTypeMappings.TryGetValue(Path.GetExtension(filename), out mime)
@@ -203,17 +204,12 @@ new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
 					context.Response.AddHeader("Date", DateTime.Now.ToString("r"));
 					context.Response.AddHeader("Last-Modified", System.IO.File.GetLastWriteTime(filename).ToString("r"));
 
-					byte[] buffer = new byte[1024 * 16];
-					int nbytes;
-					while ((nbytes = input.Read(buffer, 0, buffer.Length)) > 0)
-						context.Response.OutputStream.Write(buffer, 0, nbytes);
+					input.CopyTo(context.Response.OutputStream);
 					input.Close();
-
-					context.Response.StatusCode = (int) HttpStatusCode.OK;
-					context.Response.OutputStream.Flush();
 				}
-				catch (Exception)
+				catch (Exception e)
 				{
+					Debug.LogException(e);
 					context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 				}
 			}
@@ -221,8 +217,8 @@ new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
 			{
 				context.Response.StatusCode = (int)HttpStatusCode.NotFound;
 			}
-
-			context.Response.OutputStream.Close();
+			
+			context.Response.Close();
 		}
 #endif
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/AssetCache.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/AssetCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System.IO;
+using GLTF.Schema;
 
 namespace UnityGLTF.Cache
 {
@@ -38,7 +39,7 @@ namespace UnityGLTF.Cache
 		/// <summary>
 		/// Cache of loaded meshes
 		/// </summary>
-		public List<MeshCacheData[]> MeshCache { get; private set; }
+		public MeshCacheData[][] MeshCache { get; private set; }
 
 		/// <summary>
 		/// Cache of loaded animations
@@ -53,28 +54,22 @@ namespace UnityGLTF.Cache
 		/// <summary>
 		/// Creates an asset cache which caches objects used in scene
 		/// </summary>
-		/// <param name="imageCacheSize"></param>
-		/// <param name="textureCacheSize"></param>
-		/// <param name="materialCacheSize"></param>
-		/// <param name="bufferCacheSize"></param>
-		/// <param name="meshCacheSize"></param>
-		/// <param name="nodeCacheSize"></param>
-		public AssetCache(int imageCacheSize, int textureCacheSize, int materialCacheSize, int bufferCacheSize,
-			int meshCacheSize, int nodeCacheSize, int animationCacheSize)
+		/// <param name="root">A glTF root whose assets will eventually be cached here</param>
+		public AssetCache(GLTFRoot root)
 		{
-			ImageCache = new Texture2D[imageCacheSize];
-			ImageStreamCache = new Stream[imageCacheSize];
-			TextureCache = new TextureCacheData[textureCacheSize];
-			MaterialCache = new MaterialCacheData[materialCacheSize];
-			BufferCache = new BufferCacheData[bufferCacheSize];
-			MeshCache = new List<MeshCacheData[]>(meshCacheSize);
-			for (int i = 0; i < meshCacheSize; ++i)
+			ImageCache = new Texture2D[root.Images?.Count ?? 0];
+			ImageStreamCache = new Stream[ImageCache.Length];
+			TextureCache = new TextureCacheData[root.Textures?.Count ?? 0];
+			MaterialCache = new MaterialCacheData[root.Materials?.Count ?? 0];
+			BufferCache = new BufferCacheData[root.Buffers?.Count ?? 0];
+			MeshCache = new MeshCacheData[root.Meshes?.Count ?? 0][];
+			for (int i = 0; i < MeshCache.Length; ++i)
 			{
-				MeshCache.Add(null);
+				MeshCache[i] = new MeshCacheData[root.Meshes?[i].Primitives.Count ?? 0];
 			}
 
-			NodeCache = new GameObject[nodeCacheSize];
-			AnimationCache = new AnimationCacheData[animationCacheSize];
+			NodeCache = new GameObject[root.Nodes?.Count ?? 0];
+			AnimationCache = new AnimationCacheData[root.Animations?.Count ?? 0];
 		}
 
 		public void Dispose()

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/RefCountedCacheData.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/RefCountedCacheData.cs
@@ -25,7 +25,7 @@ namespace UnityGLTF.Cache
 		/// <summary>
 		/// Meshes used by this GLTF node.
 		/// </summary>
-		public List<MeshCacheData[]> MeshCache { get; set; }
+		public MeshCacheData[][] MeshCache { get; set; }
 
 		/// <summary>
 		/// Materials used by this GLTF node.
@@ -76,16 +76,13 @@ namespace UnityGLTF.Cache
 		private void DestroyCachedData()
 		{
 			// Destroy the cached meshes
-			for (int i = 0; i < MeshCache.Count; i++)
+			for (int i = 0; i < MeshCache.Length; i++)
 			{
-				if (MeshCache[i] != null)
+				for (int j = 0; j < MeshCache[i].Length; j++)
 				{
-					for (int j = 0; j < MeshCache[i].Length; j++)
+					if (MeshCache[i][j] != null)
 					{
-						if (MeshCache[i][j] != null)
-						{
-							MeshCache[i][j].Unload();
-						}
+						MeshCache[i][j].Unload();
 					}
 				}
 			}


### PR DESCRIPTION
* Add `GLTFSceneImporter.LoadMaterialAsync` API
* No longer flush the asset cache between LoadScene/Node/Material/Texture calls
* Add timeout to WebRequestLoader
* Fix exception in SimpleWebServer
* Make importer Construct functions asynchronous if they might load new data (images, buffers)