### PR TITLE
Removed redundant ref count increment on duplication.

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/InstantiatedGLTFObject.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/InstantiatedGLTFObject.cs
@@ -53,7 +53,6 @@ namespace UnityGLTF
 
             InstantiatedGLTFObject newGltfObjectComponent = duplicatedObject.GetComponent<InstantiatedGLTFObject>();
             newGltfObjectComponent.CachedData = CachedData;
-			CachedData.IncreaseRefCount();
 
             return newGltfObjectComponent;
         }


### PR DESCRIPTION
Remove redundant ref count increment on cachedData on duplication.
The ref count on CachedData is already incremented once within the setter of newGltfObjectComponent.CachedData.