### PR TITLE
Invert the _Glossiness Material value

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -981,7 +981,7 @@ namespace UnityGLTF
 			if (material.HasProperty("_Glossiness"))
 			{
 				var metallicGlossMap = material.GetTexture("_MetallicGlossMap");
-				pbr.RoughnessFactor = (metallicGlossMap != null) ? 1.0 : material.GetFloat("_Glossiness");
+				pbr.RoughnessFactor = (metallicGlossMap != null) ? 1.0 : 1.0 - material.GetFloat("_Glossiness");
 			}
 
 			if (material.HasProperty("_MetallicGlossMap"))


### PR DESCRIPTION
The _Glossiness value is mapped into glTF roughnessFactor value. This causes glossy materials in Unity3D to appear matte in ThreeJS viewer and vice-versa. Inverting this value fixes the issue. 