### PR TITLE
Fix matrix serialization comparison

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Schema/Node.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/Node.cs
@@ -207,7 +207,7 @@ namespace GLTF.Schema
 				writer.WriteValue(Skin.Id);
 			}
 
-			if (Matrix != Matrix4x4.Identity)
+			if (!Matrix.Equals(Matrix4x4.Identity))
 			{
 				writer.WritePropertyName("matrix");
 				writer.WriteStartArray();


### PR DESCRIPTION
The comparison of matrix class fails due to using the operator instead of .Equal causing both matrix and RST data written which fails validation