### PR TITLE
Fix texture memory leak

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/MaterialCacheData.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/MaterialCacheData.cs
@@ -1,9 +1,10 @@
 ﻿using GLTF.Schema;
+using System;
 using UnityEngine;
 
 namespace UnityGLTF.Cache
 {
-	public class MaterialCacheData
+	public class MaterialCacheData : IDisposable
 	{
 		public Material UnityMaterial { get; set; }
 		public Material UnityMaterialWithVertexColor { get; set; }
@@ -17,16 +18,18 @@ namespace UnityGLTF.Cache
 		/// <summary>
 		/// Unloads the materials in this cache.
 		/// </summary>
-		public void Unload()
+		public void Dispose()
 		{
 			if (UnityMaterial != null)
 			{
-				Object.Destroy(UnityMaterial);
+				UnityEngine.Object.Destroy(UnityMaterial);
+				UnityMaterial = null;
 			}
 
 			if (UnityMaterialWithVertexColor != null)
 			{
-				Object.Destroy(UnityMaterialWithVertexColor);
+				UnityEngine.Object.Destroy(UnityMaterialWithVertexColor);
+				UnityMaterialWithVertexColor = null;
 			}
 		}
 	}

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/MeshCacheData.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/MeshCacheData.cs
@@ -1,14 +1,15 @@
 ﻿using GLTF;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace UnityGLTF.Cache
 {
-	public class MeshCacheData
+	public class MeshCacheData : IDisposable
 	{
 		public Mesh LoadedMesh { get; set; }
 		public Dictionary<string, AttributeAccessor> MeshAttributes { get; set; }
-        public GameObject PrimitiveGO { get; set; }
+		public GameObject PrimitiveGO { get; set; }
 
 		public MeshCacheData()
 		{
@@ -18,9 +19,13 @@ namespace UnityGLTF.Cache
 		/// <summary>
 		/// Unloads the meshes in this cache.
 		/// </summary>
-		public void Unload()
+		public void Dispose()
 		{
-			Object.Destroy(LoadedMesh);
+			if (LoadedMesh != null)
+			{
+				UnityEngine.Object.Destroy(LoadedMesh);
+				LoadedMesh = null;
+			}
 		}
 	}
 }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/RefCountedCacheData.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/RefCountedCacheData.cs
@@ -112,7 +112,7 @@ namespace UnityGLTF.Cache
 				MaterialCache[i] = null;
 			}
 
-			// Destroy the cached textures
+			// Destroy the cached images
 			for (int i = 0; i < ImageCache.Length; i++)
 			{
 				if (ImageCache[i] != null)

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/RefCountedCacheData.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/RefCountedCacheData.cs
@@ -25,17 +25,30 @@ namespace UnityGLTF.Cache
 		/// <summary>
 		/// Meshes used by this GLTF node.
 		/// </summary>
-		public MeshCacheData[][] MeshCache { get; set; }
+		public MeshCacheData[][] MeshCache { get; private set; }
 
 		/// <summary>
 		/// Materials used by this GLTF node.
 		/// </summary>
-		public MaterialCacheData[] MaterialCache { get; set; }
+		public MaterialCacheData[] MaterialCache { get; private set; }
 
 		/// <summary>
 		/// Textures used by this GLTF node.
 		/// </summary>
-		public TextureCacheData[] TextureCache { get; set; }
+		public TextureCacheData[] TextureCache { get; private set; }
+
+		/// <summary>
+		/// Textures from the AssetCache that might need to be cleaned up
+		/// </summary>
+		public Texture2D[] ImageCache { get; private set; }
+
+		public RefCountedCacheData(MaterialCacheData[] materialCache, MeshCacheData[][] meshCache, TextureCacheData[] textureCache, Texture2D[] imageCache)
+		{
+			MaterialCache = materialCache;
+			MeshCache = meshCache;
+			TextureCache = textureCache;
+			ImageCache = imageCache;
+		}
 
 		public void IncreaseRefCount()
 		{
@@ -80,28 +93,32 @@ namespace UnityGLTF.Cache
 			{
 				for (int j = 0; j < MeshCache[i].Length; j++)
 				{
-					if (MeshCache[i][j] != null)
-					{
-						MeshCache[i][j].Unload();
-					}
+					MeshCache[i][j]?.Dispose();
+					MeshCache[i][j] = null;
 				}
 			}
 
 			// Destroy the cached textures
 			for (int i = 0; i < TextureCache.Length; i++)
 			{
-				if (TextureCache[i] != null)
-				{
-					TextureCache[i].Unload();
-				}
+				TextureCache[i]?.Dispose();
+				TextureCache[i] = null;
 			}
 
 			// Destroy the cached materials
 			for (int i = 0; i < MaterialCache.Length; i++)
 			{
-				if (MaterialCache[i] != null)
+				MaterialCache[i]?.Dispose();
+				MaterialCache[i] = null;
+			}
+
+			// Destroy the cached textures
+			for (int i = 0; i < ImageCache.Length; i++)
+			{
+				if (ImageCache[i] != null)
 				{
-					MaterialCache[i].Unload();
+					UnityEngine.Object.Destroy(ImageCache[i]);
+					ImageCache[i] = null;
 				}
 			}
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/TextureCacheData.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/TextureCacheData.cs
@@ -1,9 +1,10 @@
 ﻿using GLTF.Schema;
+using System;
 using UnityEngine;
 
 namespace UnityGLTF.Cache
 {
-	public class TextureCacheData
+	public class TextureCacheData : IDisposable
 	{
 		public GLTFTexture TextureDefinition;
 		public Texture Texture;
@@ -11,9 +12,13 @@ namespace UnityGLTF.Cache
 		/// <summary>
 		/// Unloads the textures in this cache.
 		/// </summary>
-		public void Unload()
+		public void Dispose()
 		{
-			Object.Destroy(Texture);
+			if (Texture != null)
+			{
+				UnityEngine.Object.Destroy(Texture);
+				Texture = null;
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Change MaterialCacheData, MeshCacheData, and TextureCacheData to IDisposable
- Add ImageCache array to RefCountedCacheData
- Dont allow replacing arrays in RefCountedCacheData after construction to prevent leaks
- Prevent recreation of TextureCacheData (leaking references to cloned textures)
- Add debug asserts to texture reference setting to ensure no leaked references