### PR TITLE
Set the correct filter mode when loading texture samplers

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -1870,11 +1870,11 @@ namespace UnityGLTF
 					{
 						case MinFilterMode.Nearest:
 						case MinFilterMode.NearestMipmapNearest:
-						case MinFilterMode.NearestMipmapLinear:
+						case MinFilterMode.LinearMipmapNearest:
 							desiredFilterMode = FilterMode.Point;
 							break;
 						case MinFilterMode.Linear:
-						case MinFilterMode.LinearMipmapNearest:
+						case MinFilterMode.NearestMipmapLinear:
 							desiredFilterMode = FilterMode.Bilinear;
 							break;
 						case MinFilterMode.LinearMipmapLinear:


### PR DESCRIPTION
The MinFilterModes of NearestMipmapLinear and LinearMipmapNearest were mapped to incorrect Unity FilterModes.  By default, textures were loaded in a way that would cause them to look "pixelated".  Now the textures are correctly anti-aliased.

NearestMipmapLinear means choose a single mip, then linear interpolate within that map.  This is precisely what FilterMode.Bilinear does.

LinearMipmapNearest means linear interpolate between the mips, but choose nearest in each mip.  This functionality is not supported in Unity, but the closest option is FilterMode.Point, which will actually implement NearestMibmapNearest.