### PR TITLE
Fix for loading performance issue

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Async/AsyncCoroutineHelper.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Async/AsyncCoroutineHelper.cs
@@ -17,6 +17,7 @@ namespace UnityGLTF
             if (Time.realtimeSinceStartup > _timeout)
             {
                 await Task.Delay(1);
+				_timeout = Time.realtimeSinceStartup + BudgetPerFrameInSeconds;
             }
         }
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Async/AsyncCoroutineHelper.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Async/AsyncCoroutineHelper.cs
@@ -17,7 +17,7 @@ namespace UnityGLTF
             if (Time.realtimeSinceStartup > _timeout)
             {
                 await Task.Delay(1);
-				_timeout = Time.realtimeSinceStartup + BudgetPerFrameInSeconds;
+                _timeout = Time.realtimeSinceStartup + BudgetPerFrameInSeconds;
             }
         }
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Editor/Integration.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Editor/Integration.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: e1c2c4a5d74bb304f8208a98cc16db22
-folderAsset: yes
-timeCreated: 1506549706
-licenseType: Pro
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
The _timeout set in ResetFrameTimeout would sometimes have already expired by the time that the Task.Delay(1) returns.  So set the timeout again at that time to ensure that we get the whole BudgetPerFrameInSeconds worth of time to do work.

In some models with many nodes, this change reduces loading times in Editor by 10x.  I haven't tested on other devices, but I believe this will address issue #400.

Also remove a meta file that Unity keeps deleting so it will stop showing up as a change.