### PR TITLE
Make all of the maps public so that callers can derive from them

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/MetalRough2StandardMap.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/MetalRough2StandardMap.cs
@@ -2,7 +2,7 @@
 
 namespace UnityGLTF
 {
-	class MetalRough2StandardMap : StandardMap, IMetalRoughUniformMap
+	public class MetalRough2StandardMap : StandardMap, IMetalRoughUniformMap
 	{
 		private Vector2 baseColorOffset = new Vector2(0, 0);
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/MetalRoughMap.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/MetalRoughMap.cs
@@ -5,7 +5,7 @@ using CullMode = UnityEngine.Rendering.CullMode;
 
 namespace UnityGLTF
 {
-	class MetalRoughMap : MetalRough2StandardMap
+	public class MetalRoughMap : MetalRough2StandardMap
 	{
 		private Vector2 metalRoughOffset = new Vector2(0, 0);
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/SpecGloss2StandardMap.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/SpecGloss2StandardMap.cs
@@ -2,7 +2,7 @@
 
 namespace UnityGLTF
 {
-	class SpecGloss2StandardMap : StandardMap, ISpecGlossUniformMap
+	public class SpecGloss2StandardMap : StandardMap, ISpecGlossUniformMap
 	{
 		private Vector2 diffuseOffset = new Vector2(0, 0);
 		private Vector2 specGlossOffset = new Vector2(0, 0);

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/SpecGlossMap.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/SpecGlossMap.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UnityGLTF
 {
-	class SpecGlossMap : SpecGloss2StandardMap
+	public class SpecGlossMap : SpecGloss2StandardMap
 	{
 		public SpecGlossMap(int MaxLOD = 1000) : base("GLTF/PbrSpecularGlossiness", MaxLOD) { }
 		public SpecGlossMap(string shaderName, int MaxLOD = 1000) : base(shaderName, MaxLOD) { }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/StandardMap.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/StandardMap.cs
@@ -7,7 +7,7 @@ using Texture = UnityEngine.Texture;
 
 namespace UnityGLTF
 {
-	class StandardMap : IUniformMap
+	public class StandardMap : IUniformMap
 	{
 		protected Material _material;
 		private AlphaMode _alphaMode = AlphaMode.OPAQUE;

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/UniformMap.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/UniformMaps/UniformMap.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace UnityGLTF
 {
-	interface IUniformMap
+	public interface IUniformMap
 	{
 		Material Material { get; }
 
@@ -42,7 +42,7 @@ namespace UnityGLTF
 		IUniformMap Clone();
 	}
 
-	interface IMetalRoughUniformMap : IUniformMap
+	public interface IMetalRoughUniformMap : IUniformMap
 	{
 		Texture BaseColorTexture { get; set; }
 		int BaseColorTexCoord { get; set; }
@@ -64,7 +64,7 @@ namespace UnityGLTF
 		double RoughnessFactor { get; set; }
 	}
 
-	interface ISpecGlossUniformMap : IUniformMap
+	public interface ISpecGlossUniformMap : IUniformMap
 	{
 		Texture DiffuseTexture { get; set; }
 		int DiffuseTexCoord { get; set; }
@@ -86,7 +86,7 @@ namespace UnityGLTF
 		double GlossinessFactor { get; set; }
 	}
 
-	interface IUnlitUniformMap : IUniformMap
+	public interface IUnlitUniformMap : IUniformMap
 	{
 		Texture BaseColorTexture { get; set; }
 		int BaseColorTexCoord { get; set; }


### PR DESCRIPTION
Previously they were internal but people were able to derive from them in some Unity projects because they'd all end up in the same assembly.  Now that we've added assemblydefs, the UnityGLTF classes are in their own assembly.