### PR TITLE
Fix uwp build

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -8,9 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.ExceptionServices;
-#if !WINDOWS_UWP
 using System.Threading;
-#endif
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Rendering;


### PR DESCRIPTION
We need System.Threading for CancellationToken that was added to this file.  Previously it was only needed for bits of code that were in #if !WINDOWS_UWP blocks.