### PR TITLE
Script compilation warning and proper coroutine usage

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Examples/OrbitCameraController.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Examples/OrbitCameraController.cs
@@ -19,7 +19,7 @@ namespace UnityGLTF.Examples
 		public float distanceMin = .5f;
 		public float distanceMax = 150f;
 
-		private Camera camera;
+		private new Camera camera;
 
 		private Rigidbody cameraRigidBody;
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Editor/GLTFSceneTests.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Tests/Editor/GLTFSceneTests.cs
@@ -46,7 +46,7 @@ public class GLTFSceneTests
 		    if (o.name.Contains("GLTF"))
 		    {
 			    GLTFComponent gltfcomponent = o.GetComponent<GLTFComponent>();
-			    gltfcomponent.Load();
+			    yield return gltfcomponent.Load().AsCoroutine();
 		    }
 	    }
 


### PR DESCRIPTION
Fixes the only two remaining script compilation warnings (wrong coroutine usage and "camera" hiding the old Unity camera)