### PR TITLE
Remove use of UnityEditor namespace

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -995,53 +995,53 @@ namespace UnityGLTF
 				{
 					for (var i = 0; i < keyframes[ci].Length; i++)
 					{
-                        SetTangentMode(curve, i, mode);
-                    }
-                }
+						SetTangentMode(curve, i, mode);
+					}
+				}
 				clip.SetCurve(relativePath, curveType, propertyNames[ci], curve);
 			}
 		}
 
-        private static void SetTangentMode(AnimationCurve curve, int keyframeIndex, InterpolationType interpolation)
-        {
-            var key = curve.keys[keyframeIndex];
+		private static void SetTangentMode(AnimationCurve curve, int keyframeIndex, InterpolationType interpolation)
+		{
+			var key = curve.keys[keyframeIndex];
 
-            switch (interpolation)
-            {
-                case InterpolationType.CATMULLROMSPLINE:
-                    key.inTangent = 0;
-                    key.outTangent = 0;
-                    break;
-                case InterpolationType.LINEAR:
-                    key.inTangent = GetCurveKeyframeLeftLinearSlope(curve, keyframeIndex);
-                    key.outTangent = GetCurveKeyframeLeftLinearSlope(curve, keyframeIndex + 1);
-                    break;
-                case InterpolationType.STEP:
-                    key.inTangent = float.PositiveInfinity;
-                    key.outTangent = float.PositiveInfinity;
-                    break;
+			switch (interpolation)
+			{
+				case InterpolationType.CATMULLROMSPLINE:
+					key.inTangent = 0;
+					key.outTangent = 0;
+					break;
+				case InterpolationType.LINEAR:
+					key.inTangent = GetCurveKeyframeLeftLinearSlope(curve, keyframeIndex);
+					key.outTangent = GetCurveKeyframeLeftLinearSlope(curve, keyframeIndex + 1);
+					break;
+				case InterpolationType.STEP:
+					key.inTangent = float.PositiveInfinity;
+					key.outTangent = float.PositiveInfinity;
+					break;
 
-                default:
-                    throw new NotImplementedException();
-            }
+				default:
+					throw new NotImplementedException();
+			}
 
-            curve.MoveKey(keyframeIndex, key);
-        }
+			curve.MoveKey(keyframeIndex, key);
+		}
 
-        private static float GetCurveKeyframeLeftLinearSlope(AnimationCurve curve, int keyframeIndex)
-        {
-            if (keyframeIndex <= 0 || keyframeIndex >= curve.keys.Length)
-            {
-                return 0;
-            }
+		private static float GetCurveKeyframeLeftLinearSlope(AnimationCurve curve, int keyframeIndex)
+		{
+			if (keyframeIndex <= 0 || keyframeIndex >= curve.keys.Length)
+			{
+				return 0;
+			}
 
-            var valueDelta = curve.keys[keyframeIndex].value - curve.keys[keyframeIndex - 1].value;
-            var timeDelta = curve.keys[keyframeIndex].time - curve.keys[keyframeIndex - 1].time;
+			var valueDelta = curve.keys[keyframeIndex].value - curve.keys[keyframeIndex - 1].value;
+			var timeDelta = curve.keys[keyframeIndex].time - curve.keys[keyframeIndex - 1].time;
 
-            Debug.Assert(timeDelta > 0, "Unity does not allow you to put two keyframes in with the same time, so this should never occur.");
+			Debug.Assert(timeDelta > 0, "Unity does not allow you to put two keyframes in with the same time, so this should never occur.");
 
-            return valueDelta / timeDelta;
-        }
+			return valueDelta / timeDelta;
+		}
 
         protected async Task<AnimationClip> ConstructClip(Transform root, int animationId, CancellationToken cancellationToken)
 		{

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -1043,7 +1043,7 @@ namespace UnityGLTF
 			return valueDelta / timeDelta;
 		}
 
-        protected async Task<AnimationClip> ConstructClip(Transform root, int animationId, CancellationToken cancellationToken)
+		protected async Task<AnimationClip> ConstructClip(Transform root, int animationId, CancellationToken cancellationToken)
 		{
 			GLTFAnimation animation = _gltfRoot.Animations[animationId];
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityGLTF.Cache;
@@ -996,34 +995,55 @@ namespace UnityGLTF
 				{
 					for (var i = 0; i < keyframes[ci].Length; i++)
 					{
-						var utilityMode = GetAnimationUtilityMode(mode);
-
-						AnimationUtility.SetKeyLeftTangentMode(curve, i, utilityMode);
-						AnimationUtility.SetKeyRightTangentMode(curve, i, utilityMode);
-					}
-				}
+                        SetTangentMode(curve, i, mode);
+                    }
+                }
 				clip.SetCurve(relativePath, curveType, propertyNames[ci], curve);
 			}
 		}
 
-		private static AnimationUtility.TangentMode GetAnimationUtilityMode(InterpolationType interpolation)
-		{
-			switch (interpolation)
-			{
-				case InterpolationType.CATMULLROMSPLINE:
-				case InterpolationType.CUBICSPLINE:
-					return AnimationUtility.TangentMode.Auto;
-				case InterpolationType.LINEAR:
-					return AnimationUtility.TangentMode.Linear;
-				case InterpolationType.STEP:
-					return AnimationUtility.TangentMode.Constant;
+        private static void SetTangentMode(AnimationCurve curve, int keyframeIndex, InterpolationType interpolation)
+        {
+            var key = curve.keys[keyframeIndex];
 
-				default:
-					throw new NotImplementedException();
-			}
-		}
+            switch (interpolation)
+            {
+                case InterpolationType.CATMULLROMSPLINE:
+                    key.inTangent = 0;
+                    key.outTangent = 0;
+                    break;
+                case InterpolationType.LINEAR:
+                    key.inTangent = GetCurveKeyframeLeftLinearSlope(curve, keyframeIndex);
+                    key.outTangent = GetCurveKeyframeLeftLinearSlope(curve, keyframeIndex + 1);
+                    break;
+                case InterpolationType.STEP:
+                    key.inTangent = float.PositiveInfinity;
+                    key.outTangent = float.PositiveInfinity;
+                    break;
 
-		protected async Task<AnimationClip> ConstructClip(Transform root, int animationId, CancellationToken cancellationToken)
+                default:
+                    throw new NotImplementedException();
+            }
+
+            curve.MoveKey(keyframeIndex, key);
+        }
+
+        private static float GetCurveKeyframeLeftLinearSlope(AnimationCurve curve, int keyframeIndex)
+        {
+            if (keyframeIndex <= 0 || keyframeIndex >= curve.keys.Length)
+            {
+                return 0;
+            }
+
+            var valueDelta = curve.keys[keyframeIndex].value - curve.keys[keyframeIndex - 1].value;
+            var timeDelta = curve.keys[keyframeIndex].time - curve.keys[keyframeIndex - 1].time;
+
+            Debug.Assert(timeDelta > 0, "Unity does not allow you to put two keyframes in with the same time, so this should never occur.");
+
+            return valueDelta / timeDelta;
+        }
+
+        protected async Task<AnimationClip> ConstructClip(Transform root, int animationId, CancellationToken cancellationToken)
 		{
 			GLTFAnimation animation = _gltfRoot.Animations[animationId];
 


### PR DESCRIPTION
UnityEditor namespace is not available when you build a player.  Implement an equivalent function as the helper that is unavailable.