### PR TITLE
Remove editor config entry for line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,5 @@ root = true
 
 [*]
 indent_style = tab
-end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
On windows by default, git will check out Windows style and commit unix style (https://stackoverflow.com/questions/10418975/how-to-change-line-ending-settings).  To support this better, just remove the .editorconfig entry for line endings.