### PR TITLE
Fix stack overflow that could occur for some models

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -1321,7 +1321,6 @@ namespace UnityGLTF
 					for (int i = 0; i < lodsextension.MeshIds.Count; i++)
 					{
 						int lodNodeId = lodsextension.MeshIds[i];
-						Debug.Log("Loading lod extension");
 						var lodNodeObj = await GetNode(lodNodeId, cancellationToken);
 						lodNodeObj.transform.SetParent(lodGroupNodeObj.transform, false);
 						childRenders = lodNodeObj.GetComponentsInChildren<MeshRenderer>();

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -274,7 +274,7 @@ namespace UnityGLTF
 				}
 			}
 
-			Debug.Assert(progressStatus.NodeLoaded == progressStatus.NodeTotal);
+			Debug.Assert(progressStatus.NodeLoaded == progressStatus.NodeTotal, $"Nodes loaded ({progressStatus.NodeLoaded}) does not match node total ({progressStatus.NodeTotal})");
 			Debug.Assert(progressStatus.TextureLoaded <= progressStatus.TextureTotal);
 
 			onLoadComplete?.Invoke(LastLoadedScene, null);
@@ -1288,21 +1288,6 @@ namespace UnityGLTF
 			nodeObj.transform.localRotation = rotation;
 			nodeObj.transform.localScale = scale;
 
-			if (node.Mesh != null)
-			{
-				await ConstructMesh(node.Mesh.Value, nodeObj.transform, node.Mesh.Id, node.Skin != null ? node.Skin.Value : null, cancellationToken);
-			}
-			/* TODO: implement camera (probably a flag to disable for VR as well)
-			if (camera != null)
-			{
-				GameObject cameraObj = camera.Value.Create();
-				cameraObj.transform.parent = nodeObj.transform;
-			}
-			*/
-
-			progressStatus.NodeLoaded++;
-			progress?.Report(progressStatus);
-
 			if (node.Children != null)
 			{
 				foreach (var child in node.Children)
@@ -1365,6 +1350,20 @@ namespace UnityGLTF
 				}
 			}
 
+			if (node.Mesh != null)
+			{
+				await ConstructMesh(node.Mesh.Value, nodeObj.transform, node.Mesh.Id, node.Skin != null ? node.Skin.Value : null, cancellationToken);
+			}
+			/* TODO: implement camera (probably a flag to disable for VR as well)
+			if (camera != null)
+			{
+				GameObject cameraObj = camera.Value.Create();
+				cameraObj.transform.parent = nodeObj.transform;
+			}
+			*/
+
+			progressStatus.NodeLoaded++;
+			progress?.Report(progressStatus);
 		}
 
 		float GetLodCoverage(List<double> lodcoverageExtras, int lodIndex)

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -274,8 +274,8 @@ namespace UnityGLTF
 				}
 			}
 
-			Debug.Assert(progressStatus.NodeLoaded == progressStatus.NodeTotal, $"Nodes loaded ({progressStatus.NodeLoaded}) does not match node total ({progressStatus.NodeTotal})");
-			Debug.Assert(progressStatus.TextureLoaded <= progressStatus.TextureTotal);
+			Debug.Assert(progressStatus.NodeLoaded == progressStatus.NodeTotal, $"Nodes loaded ({progressStatus.NodeLoaded}) does not match node total in the scene ({progressStatus.NodeTotal})");
+			Debug.Assert(progressStatus.TextureLoaded <= progressStatus.TextureTotal, $"Textures loaded ({progressStatus.TextureLoaded}) is larger than texture total in the scene ({progressStatus.TextureTotal})");
 
 			onLoadComplete?.Invoke(LastLoadedScene, null);
 		}
@@ -596,8 +596,6 @@ namespace UnityGLTF
 			_lastLoadedScene = CreatedObject;
 		}
 
-		private HashSet<int> sceneNodes = new HashSet<int>();
-
 		private void GetGtlfContentTotals(GLTFScene scene)
 		{
 			// Count Nodes
@@ -617,7 +615,6 @@ namespace UnityGLTF
 			{
 				var cur = nodeQueue.Dequeue();
 				progressStatus.NodeTotal++;
-				sceneNodes.Add(cur.Id);
 
 				if (cur.Value.Children != null)
 				{
@@ -1271,11 +1268,6 @@ namespace UnityGLTF
 			if (_assetCache.NodeCache[nodeIndex] != null)
 			{
 				return;
-			}
-
-			if (!sceneNodes.Contains(nodeIndex))
-			{
-				Debug.LogError("Node not in the scene");
 			}
 
 			var nodeObj = new GameObject(string.IsNullOrEmpty(node.Name) ? ("GLTFNode" + nodeIndex) : node.Name);


### PR DESCRIPTION
For some models, there are circular references where a node points to a mesh which points to a skinned animation, which points back to the original node.  This caused infinite recursion resulting in a stack overflow.

The fix is to load the subnodes prior to loading the mesh data.  There might be a better fix where all nodes are loaded, then all meshes are loaded.  But that was a much more substantial fix, so going with this one for now.