### PR TITLE
Handle low memory situations and change API of Importer/Exporter to take in option classes

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Examples/GLTFExporterTest.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Examples/GLTFExporterTest.cs
@@ -5,15 +5,10 @@ namespace UnityGLTF.Examples
 {
 	public class GLTFExporterTest : MonoBehaviour
 	{
-		public string RetrieveTexturePath(UnityEngine.Texture texture)
-		{
-			return texture.name;
-		}
-
 		// Use this for initialization
 		void Awake()
 		{
-			var exporter = new GLTFSceneExporter(new[] {transform}, RetrieveTexturePath);
+			var exporter = new GLTFSceneExporter(new[] {transform}, new ExportOptions());
 			var appPath = Application.dataPath;
 			var wwwPath = appPath.Substring(0, appPath.LastIndexOf("Assets")) + "www";
 			exporter.SaveGLTFandBin(Path.Combine(wwwPath, "TestScene"), "TestScene");

--- a/UnityGLTF/Assets/UnityGLTF/Examples/MultiSceneComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Examples/MultiSceneComponent.cs
@@ -11,17 +11,19 @@ namespace UnityGLTF.Examples
 		public string Url;
 
 		private GLTFSceneImporter _importer;
-		private AsyncCoroutineHelper _asyncCoroutineHelper;
-		private ILoader _loader;
+		private ImportOptions _importOptions;
 		private string _fileName;
 
 		void Start()
 		{
 			Debug.Log("Hit spacebar to change the scene.");
-			_asyncCoroutineHelper = gameObject.AddComponent<AsyncCoroutineHelper>();
 			Uri uri = new Uri(Url);
 			var directoryPath = URIHelper.AbsoluteUriPath(uri);
-			_loader = new WebRequestLoader(directoryPath);
+			_importOptions = new ImportOptions
+			{
+				ExternalDataLoader = new WebRequestLoader(directoryPath),
+				AsyncCoroutineHelper = gameObject.AddComponent<AsyncCoroutineHelper>(),
+			};
 			_fileName = URIHelper.GetFileFromUri(uri);
 
 			LoadScene(SceneIndex);
@@ -46,8 +48,7 @@ namespace UnityGLTF.Examples
 
 			_importer = new GLTFSceneImporter(
 				_fileName,
-				_loader,
-				_asyncCoroutineHelper
+				_importOptions
 				);
 			
 			_importer.SceneParent = gameObject.transform;

--- a/UnityGLTF/Assets/UnityGLTF/Examples/RootMergeComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Examples/RootMergeComponent.cs
@@ -69,9 +69,12 @@ namespace UnityGLTF
 			}
 			GLTFSceneImporter importer = new GLTFSceneImporter(
 				asset1Root,
-				loader1,
-				gameObject.AddComponent<AsyncCoroutineHelper>()
-				);
+				null,
+				new ImportOptions
+				{
+					ExternalDataLoader = loader1,
+					AsyncCoroutineHelper = gameObject.AddComponent<AsyncCoroutineHelper>()
+				});
 
 			importer.MaximumLod = MaximumLod;
 			importer.IsMultithreaded = Multithreaded;

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFExportMenu.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFExportMenu.cs
@@ -42,7 +42,8 @@ public class GLTFExportMenu : EditorWindow
 		else
 			throw new Exception("No objects selected, cannot export.");
 
-		var exporter = new GLTFSceneExporter(Selection.transforms, RetrieveTexturePath);
+		var exportOptions = new ExportOptions { TexturePathRetriever = RetrieveTexturePath };
+		var exporter = new GLTFSceneExporter(Selection.transforms, exportOptions);
 
 		var path = EditorUtility.OpenFolderPanel("glTF Export Path", "", "");
 		if (!string.IsNullOrEmpty(path)) {
@@ -61,7 +62,8 @@ public class GLTFExportMenu : EditorWindow
 		else
 			throw new Exception("No objects selected, cannot export.");
 
-		var exporter = new GLTFSceneExporter(Selection.transforms, RetrieveTexturePath);
+		var exportOptions = new ExportOptions { TexturePathRetriever = RetrieveTexturePath };
+		var exporter = new GLTFSceneExporter(Selection.transforms, exportOptions);
 
 		var path = EditorUtility.OpenFolderPanel("glTF Export Path", "", "");
 		if (!string.IsNullOrEmpty(path))
@@ -77,7 +79,8 @@ public class GLTFExportMenu : EditorWindow
 		var gameObjects = scene.GetRootGameObjects();
 		var transforms = Array.ConvertAll(gameObjects, gameObject => gameObject.transform);
 
-		var exporter = new GLTFSceneExporter(transforms, RetrieveTexturePath);
+		var exportOptions = new ExportOptions { TexturePathRetriever = RetrieveTexturePath };
+		var exporter = new GLTFSceneExporter(transforms, exportOptions);
 		var path = EditorUtility.OpenFolderPanel("glTF Export Path", "", "");
 		if (path != "") {
 			exporter.SaveGLTFandBin (path, scene.name);

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
@@ -334,12 +334,15 @@ namespace UnityGLTF
 
         private GameObject CreateGLTFScene(string projectFilePath)
         {
-			ILoader fileLoader = new FileLoader(Path.GetDirectoryName(projectFilePath));
+			var importOptions = new ImportOptions
+			{
+				ExternalDataLoader = new FileLoader(Path.GetDirectoryName(projectFilePath)),
+			};
 			using (var stream = File.OpenRead(projectFilePath))
 			{
 				GLTFRoot gLTFRoot;
 				GLTFParser.ParseJson(stream, out gLTFRoot);
-				var loader = new GLTFSceneImporter(gLTFRoot, fileLoader, null, stream);
+				var loader = new GLTFSceneImporter(gLTFRoot, stream, importOptions);
 				loader.MaximumLod = _maximumLod;
 				loader.IsMultithreaded = true;
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Factories/ImporterFactory.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Factories/ImporterFactory.cs
@@ -5,14 +5,14 @@ namespace UnityGLTF
 {
 	public abstract class ImporterFactory : ScriptableObject
 	{
-		public abstract GLTFSceneImporter CreateSceneImporter(string gltfFileName, ILoader externalDataLoader, AsyncCoroutineHelper asyncCoroutineHelper);
+		public abstract GLTFSceneImporter CreateSceneImporter(string gltfFileName, ImportOptions options);
 	}
 
 	public class DefaultImporterFactory : ImporterFactory
 	{
-		public override GLTFSceneImporter CreateSceneImporter(string gltfFileName, ILoader externalDataLoader, AsyncCoroutineHelper asyncCoroutineHelper)
+		public override GLTFSceneImporter CreateSceneImporter(string gltfFileName, ImportOptions options)
 		{
-			return new GLTFSceneImporter(gltfFileName, externalDataLoader, asyncCoroutineHelper);
+			return new GLTFSceneImporter(gltfFileName, options);
 		}
 	}
 }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -11,15 +11,15 @@ using WrapMode = GLTF.Schema.WrapMode;
 
 namespace UnityGLTF
 {
+	public class ExportOptions
+	{
+		public GLTFSceneExporter.RetrieveTexturePathDelegate TexturePathRetriever = (texture) => texture.name;
+		public bool ExportInactivePrimitives = true;
+	}
+
 	public class GLTFSceneExporter
 	{
 		public delegate string RetrieveTexturePathDelegate(Texture texture);
-
-		public class ExportOptions
-		{
-			public RetrieveTexturePathDelegate TexturePathRetriever = (texture) => texture.name;
-			public bool ExportInactivePrimitives = true;
-		}
 
 		private enum IMAGETYPE
 		{

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -15,6 +15,12 @@ namespace UnityGLTF
 	{
 		public delegate string RetrieveTexturePathDelegate(Texture texture);
 
+		public class ExportOptions
+		{
+			public RetrieveTexturePathDelegate TexturePathRetriever = (texture) => texture.name;
+			public bool ExportInactivePrimitives = true;
+		}
+
 		private enum IMAGETYPE
 		{
 			RGB,
@@ -53,7 +59,7 @@ namespace UnityGLTF
 		private List<Material> _materials;
 		private bool _shouldUseInternalBufferForImages;
 
-		private RetrieveTexturePathDelegate _retrieveTexturePathDelegate;
+		private ExportOptions _exportOptions;
 
 		private Material _metalGlossChannelSwapMaterial;
 		private Material _normalChannelMaterial;
@@ -82,9 +88,19 @@ namespace UnityGLTF
 		/// Create a GLTFExporter that exports out a transform
 		/// </summary>
 		/// <param name="rootTransforms">Root transform of object to export</param>
-		public GLTFSceneExporter(Transform[] rootTransforms, RetrieveTexturePathDelegate retrieveTexturePathDelegate)
+		[Obsolete]
+		public GLTFSceneExporter(Transform[] rootTransforms, RetrieveTexturePathDelegate texturePathRetriever)
+			: this(rootTransforms, new ExportOptions { TexturePathRetriever = texturePathRetriever })
 		{
-			_retrieveTexturePathDelegate = retrieveTexturePathDelegate;
+		}
+
+		/// <summary>
+		/// Create a GLTFExporter that exports out a transform
+		/// </summary>
+		/// <param name="rootTransforms">Root transform of object to export</param>
+		public GLTFSceneExporter(Transform[] rootTransforms, ExportOptions options)
+		{
+			_exportOptions = options;
 
 			var metalGlossChannelSwapShader = Resources.Load("MetalGlossChannelSwap", typeof(Shader)) as Shader;
 			_metalGlossChannelSwapMaterial = new Material(metalGlossChannelSwapShader);
@@ -412,7 +428,7 @@ namespace UnityGLTF
 
 		private string ConstructImageFilenamePath(Texture2D texture, string outputPath)
 		{
-			var imagePath = _retrieveTexturePathDelegate(texture);
+			var imagePath = _exportOptions.TexturePathRetriever(texture);
 			if (string.IsNullOrEmpty(imagePath))
 			{
 				imagePath = Path.Combine(outputPath, texture.name);
@@ -1254,7 +1270,7 @@ namespace UnityGLTF
 				textureMapType = texturMapType
 			});
 
-			var imagePath =_retrieveTexturePathDelegate(texture);
+			var imagePath = _exportOptions.TexturePathRetriever(texture);
 			if (string.IsNullOrEmpty(imagePath))
 			{
 				imagePath = texture.name;

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -88,7 +88,7 @@ namespace UnityGLTF
 		/// Create a GLTFExporter that exports out a transform
 		/// </summary>
 		/// <param name="rootTransforms">Root transform of object to export</param>
-		[Obsolete]
+		[Obsolete("Please switch to GLTFSceneExporter(Transform[] rootTransforms, ExportOptions options).  This constructor is deprecated and will be removed in a future release.")]
 		public GLTFSceneExporter(Transform[] rootTransforms, RetrieveTexturePathDelegate texturePathRetriever)
 			: this(rootTransforms, new ExportOptions { TexturePathRetriever = texturePathRetriever })
 		{

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -28,7 +28,7 @@ namespace UnityGLTF
 	{
 		public ILoader ExternalDataLoader = null;
 		public AsyncCoroutineHelper AsyncCoroutineHelper = null;
-		public bool CheckForLowMemory = true;
+		public bool ThrowOnLowMemory = true;
 	}
 
 	public struct MeshConstructionData
@@ -231,7 +231,7 @@ namespace UnityGLTF
 			}
 		}
 
-		[Obsolete]
+		[Obsolete("Only called by obsolete public constructors.  This will be removed when those obsolete constructors are removed.")]
 		private GLTFSceneImporter(ILoader externalDataLoader, AsyncCoroutineHelper asyncCoroutineHelper)
 		{
 			_options = new ImportOptions
@@ -273,7 +273,7 @@ namespace UnityGLTF
 					_isRunning = true;
 				}
 
-				if (_options.CheckForLowMemory)
+				if (_options.ThrowOnLowMemory)
 				{
 					_memoryChecker = new MemoryChecker();
 				}
@@ -751,7 +751,7 @@ namespace UnityGLTF
 					}
 				}
 
-				await YieldOnTimeoutAndCheckMemory();
+				await YieldOnTimeoutAndThrowOnLowMemory();
 				await ConstructUnityTexture(stream, markGpuOnly, isLinear, image, imageCacheIndex);
 			}
 		}
@@ -765,7 +765,7 @@ namespace UnityGLTF
 			{
 				using (MemoryStream memoryStream = stream as MemoryStream)
 				{
-					await YieldOnTimeoutAndCheckMemory();
+					await YieldOnTimeoutAndThrowOnLowMemory();
 					texture.LoadImage(memoryStream.ToArray(), markGpuOnly);
 				}
 			}
@@ -780,7 +780,7 @@ namespace UnityGLTF
 				}
 				stream.Read(buffer, 0, (int)stream.Length);
 
-				await YieldOnTimeoutAndCheckMemory();
+				await YieldOnTimeoutAndThrowOnLowMemory();
 				//	NOTE: the second parameter of LoadImage() marks non-readable, but we can't mark it until after we call Apply()
 				texture.LoadImage(buffer, markGpuOnly);
 			}
@@ -1834,7 +1834,7 @@ namespace UnityGLTF
 			int vertexCount = (int)primitive.Attributes[SemanticProperties.POSITION].Value.Count;
 			bool hasNormals = unityMeshData.Normals != null;
 
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			Mesh mesh = new Mesh
 			{
 
@@ -1844,25 +1844,25 @@ namespace UnityGLTF
 			};
 
 			mesh.vertices = unityMeshData.Vertices;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			mesh.normals = unityMeshData.Normals;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			mesh.uv = unityMeshData.Uv1;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			mesh.uv2 = unityMeshData.Uv2;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			mesh.uv3 = unityMeshData.Uv3;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			mesh.uv4 = unityMeshData.Uv4;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			mesh.colors = unityMeshData.Colors;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			mesh.triangles = unityMeshData.Triangles;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			mesh.tangents = unityMeshData.Tangents;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 			mesh.boneWeights = unityMeshData.BoneWeights;
-			await YieldOnTimeoutAndCheckMemory();
+			await YieldOnTimeoutAndThrowOnLowMemory();
 
 			if (!hasNormals)
 			{
@@ -2272,9 +2272,9 @@ namespace UnityGLTF
 			else return null;
 		}
 
-		protected async Task YieldOnTimeoutAndCheckMemory()
+		protected async Task YieldOnTimeoutAndThrowOnLowMemory()
 		{
-			if (_options.CheckForLowMemory)
+			if (_options.ThrowOnLowMemory)
 			{
 				_memoryChecker.ThrowIfOutOfMemory();
 			}

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -243,10 +243,7 @@ namespace UnityGLTF
 
 		public void Dispose()
 		{
-			if (_assetCache != null)
-			{
-				Cleanup();
-			}
+			Cleanup();
 		}
 
 		public GameObject LastLoadedScene
@@ -2319,8 +2316,11 @@ namespace UnityGLTF
 		/// </summary>
 		private void Cleanup()
 		{
-			_assetCache.Dispose();
-			_assetCache = null;
+			if (_assetCache != null)
+			{
+				_assetCache.Dispose();
+				_assetCache = null;
+			}
 		}
 	}
 }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/MemoryChecker.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/MemoryChecker.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using UnityEngine;
+#if WINDOWS_UWP
+using Windows.System;
+#endif
 
 namespace UnityGLTF
 {
@@ -7,19 +10,25 @@ namespace UnityGLTF
 	{
 		private bool outOfMemory = false;
 
+		/// <summary>
+		/// Allows polling for app low memory situation.  Listens to Application.lowMemory, which works for iOS and Android.
+		/// Also listens to Windows-specific MemoryManager.AppMemoryUsageIncreased.
+		/// </summary>
 		public MemoryChecker()
 		{
 			Application.lowMemory += Application_lowMemory;
 
 #if WINDOWS_UWP
-        MemoryManager.AppMemoryUsageIncreased += MemoryManager_AppMemoryUsageIncreased;
+			MemoryManager.AppMemoryUsageIncreased += MemoryManager_AppMemoryUsageIncreased;
 #endif
 		}
 
+		/// <summary>
+		/// If the OS has notified the app that it is low on memory since MemoryChecker was constructed, this method will throw an OutOfMemoryException.
+		/// Once it throws once, it will continue to throw.  Callers are advised to construct a new MemoryChecker after memory usage has gone down.
+		/// </summary>
 		public void ThrowIfOutOfMemory()
 		{
-			//TODO: when should we reset outOfMemory to false?
-
 			if (outOfMemory)
 			{
 				throw new OutOfMemoryException();
@@ -32,13 +41,13 @@ namespace UnityGLTF
 		}
 
 #if WINDOWS_UWP
-    private void MemoryManager_AppMemoryUsageIncreased(object sender, object e)
-    {
-        if (MemoryManager.AppMemoryUsageLevel == AppMemoryUsageLevel.OverLimit)
-        {
-            outOfMemory = true;
-        }
-    }
+		private void MemoryManager_AppMemoryUsageIncreased(object sender, object e)
+		{
+			if (MemoryManager.AppMemoryUsageLevel == AppMemoryUsageLevel.OverLimit)
+			{
+				outOfMemory = true;
+			}
+		}
 #endif
 	}
 }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/MemoryChecker.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/MemoryChecker.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using UnityEngine;
+
+namespace UnityGLTF
+{
+	public class MemoryChecker
+	{
+		private bool outOfMemory = false;
+
+		public MemoryChecker()
+		{
+			Application.lowMemory += Application_lowMemory;
+
+#if WINDOWS_UWP
+        MemoryManager.AppMemoryUsageIncreased += MemoryManager_AppMemoryUsageIncreased;
+#endif
+		}
+
+		public void ThrowIfOutOfMemory()
+		{
+			//TODO: when should we reset outOfMemory to false?
+
+			if (outOfMemory)
+			{
+				throw new OutOfMemoryException();
+			}
+		}
+
+		private void Application_lowMemory()
+		{
+			outOfMemory = true;
+		}
+
+#if WINDOWS_UWP
+    private void MemoryManager_AppMemoryUsageIncreased(object sender, object e)
+    {
+        if (MemoryManager.AppMemoryUsageLevel == AppMemoryUsageLevel.OverLimit)
+        {
+            outOfMemory = true;
+        }
+    }
+#endif
+	}
+}

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/MemoryChecker.cs.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/MemoryChecker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bde1c330cae17541b9fb48d321d1722
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Handle low memory situations when loading a scene.  Fixes issue #432.
   - Under memory pressure, calls to Texture2D.LoadImage() can cause the app to crash in an un-catchable way.
   - On iOS, Android, and non-desktop Windows (Hololens, etc.), the OS will notify an app if it is using too much memory before it actually runs out.
   - We now listen to low memory events during loading.  If it fires, we remove the partially loaded model and throw an OutOfMemoryException.  Callers can opt out of this functionality using the ImportOptions if they wish.
- Change the API of GLTFSceneImporter and GLTFSceneExporter to take in option objects.
   - Old API is marked as obsolete, but will still work for now.
   - The plan is to remove the old constructors in a future change.