### PR TITLE
Add support for points and lines

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
@@ -100,15 +100,13 @@ namespace GLTF.Schema
 
 		public static int[] GenerateIndices(int vertCount)
 		{
-			var arr = new int[vertCount];
-			for (var i = 0; i < vertCount; i+=3)
+			var indices = new int[vertCount];
+			for (var i = 0; i < vertCount; i++)
 			{
-				arr[i] = i + 2;
-				arr[i + 1] = i + 1;
-				arr[i + 2] = i;
+				indices[i] = i;
 			}
 
-			return arr;
+			return indices;
 		}
 
 		// Taken from: http://answers.unity3d.com/comments/190515/view.html

--- a/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
@@ -98,7 +98,7 @@ namespace GLTF.Schema
 			}
 		}
 
-		public static int[] GenerateTriangles(int vertCount)
+		public static int[] GenerateIndices(int vertCount)
 		{
 			var arr = new int[vertCount];
 			for (var i = 0; i < vertCount; i+=3)

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
@@ -90,7 +90,7 @@ namespace UnityGLTF
                     {
                         mesh.normals = new Vector3[0];
                     }
-                    if (_importNormals == GLTFImporterNormals.Calculate)
+                    if (_importNormals == GLTFImporterNormals.Calculate && mesh.GetTopology(0) == MeshTopology.Triangles)
                     {
                         mesh.RecalculateNormals();
                     }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Extensions/SchemaExtensions.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Extensions/SchemaExtensions.cs
@@ -445,33 +445,14 @@ namespace UnityGLTF.Extensions
 		/// Rewinds the indicies into Unity coordinate space from glTF space
 		/// </summary>
 		/// <param name="attributeAccessor">The attribute accessor to modify</param>
-		public static void FlipFaces(ref AttributeAccessor attributeAccessor)
+		public static void FlipTriangleFaces(int[] indices)
 		{
-			for (int i = 0; i < attributeAccessor.AccessorContent.AsTriangles.Length; i += 3)
+			for (int i = 0; i < indices.Length; i += 3)
 			{
-				uint temp = attributeAccessor.AccessorContent.AsUInts[i];
-				attributeAccessor.AccessorContent.AsUInts[i] = attributeAccessor.AccessorContent.AsUInts[i + 2];
-				attributeAccessor.AccessorContent.AsUInts[i + 2] = temp;
+				int temp = indices[i];
+				indices[i] = indices[i + 2];
+				indices[i + 2] = temp;
 			}
-		}
-
-		/// <summary>
-		/// Rewinds the indices from glTF space to Unity space
-		/// </summary>
-		/// <param name="triangles">The indices to copy and modify</param>
-		/// <returns>Indices in glTF space that are copied</returns>
-		public static int[] FlipFacesAndCopy(int[] triangles)
-		{
-			int[] returnArr = new int[triangles.Length];
-			for (int i = 0; i < triangles.Length; i += 3)
-			{
-				int temp = triangles[i];
-				returnArr[i] = triangles[i + 2];
-				returnArr[i + 1] = triangles[i + 1];
-				returnArr[i + 2] = temp;
-			}
-
-			return returnArr;
 		}
 
 		public static Matrix4x4 ToUnityMatrix4x4(this GLTF.Math.Matrix4x4 matrix)

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -760,8 +760,11 @@ namespace UnityGLTF
 			{
 				var primitive = new MeshPrimitive();
 
+				var topology = meshObj.GetTopology(submesh);
 				var indices = meshObj.GetIndices(submesh);
-				SchemaExtensions.FlipTriangleFaces(indices);
+				if (topology == MeshTopology.Triangles) SchemaExtensions.FlipTriangleFaces(indices);
+
+				primitive.Mode = GetDrawMode(topology);
 				primitive.Indices = ExportAccessor(indices, true);
 
 				primitive.Attributes = new Dictionary<string, AccessorId>();
@@ -1948,6 +1951,19 @@ namespace UnityGLTF
 			}
 
 			return null;
+		}
+
+		protected static DrawMode GetDrawMode(MeshTopology topology)
+		{
+			switch (topology)
+			{
+				case MeshTopology.Points: return DrawMode.Points;
+				case MeshTopology.Lines: return DrawMode.Lines;
+				case MeshTopology.LineStrip: return DrawMode.LineStrip;
+				case MeshTopology.Triangles: return DrawMode.Triangles;
+			}
+
+			throw new Exception("glTF does not support Unity mesh topology: " + topology);
 		}
 	}
 }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -760,8 +760,8 @@ namespace UnityGLTF
 			{
 				var primitive = new MeshPrimitive();
 
-				var triangles = meshObj.GetTriangles(submesh);
-				primitive.Indices = ExportAccessor(SchemaExtensions.FlipFacesAndCopy(triangles), true);
+				var indices = meshObj.GetIndices(submesh);
+				primitive.Indices = ExportAccessor(SchemaExtensions.FlipFacesAndCopy(indices), true);
 
 				primitive.Attributes = new Dictionary<string, AccessorId>();
 				primitive.Attributes.Add(SemanticProperties.POSITION, aPosition);
@@ -1948,6 +1948,5 @@ namespace UnityGLTF
 
 			return null;
 		}
-
 	}
 }

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -761,7 +761,8 @@ namespace UnityGLTF
 				var primitive = new MeshPrimitive();
 
 				var indices = meshObj.GetIndices(submesh);
-				primitive.Indices = ExportAccessor(SchemaExtensions.FlipFacesAndCopy(indices), true);
+				SchemaExtensions.FlipTriangleFaces(indices);
+				primitive.Indices = ExportAccessor(indices, true);
 
 				primitive.Attributes = new Dictionary<string, AccessorId>();
 				primitive.Attributes.Add(SemanticProperties.POSITION, aPosition);

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -39,7 +39,7 @@ namespace UnityGLTF
 		public Vector2[] Uv3;
 		public Vector2[] Uv4;
 		public Color[] Colors;
-		public int[] Triangles;
+		public int[] Indices;
 		public Vector4[] Tangents;
 		public BoneWeight[] BoneWeights;
 	}
@@ -1662,9 +1662,9 @@ namespace UnityGLTF
 					? meshAttributes[SemanticProperties.Color(0)].AccessorContent.AsColors.ToUnityColorRaw()
 					: null,
 
-				Triangles = primitive.Indices != null
+				Indices = primitive.Indices != null
 					? meshAttributes[SemanticProperties.INDICES].AccessorContent.AsUInts.ToIntArrayRaw()
-					: MeshPrimitive.GenerateTriangles(vertexCount),
+					: MeshPrimitive.GenerateIndices(vertexCount),
 
 				Tangents = primitive.Attributes.ContainsKey(SemanticProperties.TANGENT)
 					? meshAttributes[SemanticProperties.TANGENT].AccessorContent.AsTangents.ToUnityVector4Raw()
@@ -1781,7 +1781,7 @@ namespace UnityGLTF
 			if (_asyncCoroutineHelper != null) await _asyncCoroutineHelper.YieldOnTimeout();
 			mesh.colors = unityMeshData.Colors;
 			if (_asyncCoroutineHelper != null) await _asyncCoroutineHelper.YieldOnTimeout();
-			mesh.triangles = unityMeshData.Triangles;
+			mesh.SetIndices(unityMeshData.Indices, MeshTopology.Triangles, 0);
 			if (_asyncCoroutineHelper != null) await _asyncCoroutineHelper.YieldOnTimeout();
 			mesh.tangents = unityMeshData.Tangents;
 			if (_asyncCoroutineHelper != null) await _asyncCoroutineHelper.YieldOnTimeout();

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -863,11 +863,6 @@ namespace UnityGLTF
 				AttributeAccessor attributeAccessor = attributeAccessors[SemanticProperties.POSITION];
 				SchemaExtensions.ConvertVector3CoordinateSpace(ref attributeAccessor, SchemaExtensions.CoordinateSpaceConversionScale);
 			}
-			if (attributeAccessors.ContainsKey(SemanticProperties.INDICES))
-			{
-				AttributeAccessor attributeAccessor = attributeAccessors[SemanticProperties.INDICES];
-				SchemaExtensions.FlipFaces(ref attributeAccessor);
-			}
 			if (attributeAccessors.ContainsKey(SemanticProperties.NORMAL))
 			{
 				AttributeAccessor attributeAccessor = attributeAccessors[SemanticProperties.NORMAL];
@@ -1632,6 +1627,12 @@ namespace UnityGLTF
 
 			int vertexCount = (int)primitive.Attributes[SemanticProperties.POSITION].Value.Count;
 
+			var indices = primitive.Indices != null
+					? meshAttributes[SemanticProperties.INDICES].AccessorContent.AsUInts.ToIntArrayRaw()
+					: MeshPrimitive.GenerateIndices(vertexCount);
+
+			SchemaExtensions.FlipTriangleFaces(indices);
+
 			return new UnityMeshData
 			{
 				Vertices = primitive.Attributes.ContainsKey(SemanticProperties.POSITION)
@@ -1662,9 +1663,7 @@ namespace UnityGLTF
 					? meshAttributes[SemanticProperties.Color(0)].AccessorContent.AsColors.ToUnityColorRaw()
 					: null,
 
-				Indices = primitive.Indices != null
-					? meshAttributes[SemanticProperties.INDICES].AccessorContent.AsUInts.ToIntArrayRaw()
-					: MeshPrimitive.GenerateIndices(vertexCount),
+				Indices = indices,
 
 				Tangents = primitive.Attributes.ContainsKey(SemanticProperties.TANGENT)
 					? meshAttributes[SemanticProperties.TANGENT].AccessorContent.AsTangents.ToUnityVector4Raw()

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -1790,7 +1790,7 @@ namespace UnityGLTF
 			mesh.boneWeights = unityMeshData.BoneWeights;
 			if (_asyncCoroutineHelper != null) await _asyncCoroutineHelper.YieldOnTimeout();
 
-			if (!hasNormals)
+			if (!hasNormals && unityMeshData.Topology == MeshTopology.Triangles)
 			{
 				mesh.RecalculateNormals();
 			}


### PR DESCRIPTION
The PR does the following:

- Remove assumptions about indices always being triangles.
- Unify different parts of the code that needs to flip triangle faces.
- Add support for importing and exporting models with points, lines, and/or line-stips.
