### PR TITLE
Fix editor import bug `File length does not match chunk header.`

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Editor/GLTFImporter.cs
@@ -339,7 +339,7 @@ namespace UnityGLTF
 			{
 				GLTFRoot gLTFRoot;
 				GLTFParser.ParseJson(stream, out gLTFRoot);
-				var loader = new GLTFSceneImporter(gLTFRoot, fileLoader, null, stream);
+				var loader = new GLTFSceneImporter(gLTFRoot, fileLoader, null, stream, 0);
 				loader.MaximumLod = _maximumLod;
 				loader.IsMultithreaded = true;
 

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -192,13 +192,13 @@ namespace UnityGLTF
 			_gltfFileName = gltfFileName;
 		}
 
-		public GLTFSceneImporter(GLTFRoot rootNode, ILoader externalDataLoader, AsyncCoroutineHelper asyncCoroutineHelper, Stream gltfStream = null) : this(externalDataLoader, asyncCoroutineHelper)
+		public GLTFSceneImporter(GLTFRoot rootNode, ILoader externalDataLoader, AsyncCoroutineHelper asyncCoroutineHelper, Stream gltfStream = null, int startPosition = 0) : this(externalDataLoader, asyncCoroutineHelper)
 		{
 			_gltfRoot = rootNode;
 			_loader = externalDataLoader;
 			if (gltfStream != null)
 			{
-				_gltfStream = new GLBStream { Stream = gltfStream, StartPosition = gltfStream.Position };
+				_gltfStream = new GLBStream { Stream = gltfStream, StartPosition = startPosition };
 			}
 		}
 


### PR DESCRIPTION
The PR fixes a somewhat common bug when importing `.glb` files via the Unity Editor. The bug has been reported at least twice (#166 and #223) and the PR has been tested and verified to fix the issue in both cases.

When importing some valid GLB files (like the ones referenced in the reported issues) a `GLTFHeaderInvalidException` is thrown with the message `File length does not match chunk header.`. Although the error happens in `GLTFParser.SeekToBinaryChunk`, the root cause is a simple false assumption made in `GLTFImporter.CreateGLTFScene`. After the call to `GLTFParser.ParseJson`, the expectation seems to be that the file stream's read position should still be at the start of the GLB file, which may actually be false. So when `GLTFSceneImporter._gltfStream.StartPosition` is initialized to the file stream's current position, assuming it's at the start - it leads to an incorrect start position being passed to `SeekToBinaryChunk`.
