### PR TITLE
[Bugfix] Release RenderTexture correctly when exporting textures

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneExporter.cs
@@ -360,7 +360,7 @@ namespace UnityGLTF
 			var finalFilenamePath = ConstructImageFilenamePath(texture, outputPath);
 			File.WriteAllBytes(finalFilenamePath, exportTexture.EncodeToPNG());
 
-			destRenderTexture.Release();
+			RenderTexture.ReleaseTemporary(destRenderTexture);
 			if (Application.isEditor)
 			{
 				GameObject.DestroyImmediate(exportTexture);
@@ -390,8 +390,7 @@ namespace UnityGLTF
 			var finalFilenamePath = ConstructImageFilenamePath(texture, outputPath);
 			File.WriteAllBytes(finalFilenamePath, exportTexture.EncodeToPNG());
 
-			destRenderTexture.Release();
-
+			RenderTexture.ReleaseTemporary(destRenderTexture);
 			if (Application.isEditor)
 			{
 				GameObject.DestroyImmediate(exportTexture);
@@ -415,7 +414,7 @@ namespace UnityGLTF
 			var finalFilenamePath = ConstructImageFilenamePath(texture, outputPath);
 			File.WriteAllBytes(finalFilenamePath, exportTexture.EncodeToPNG());
 
-			destRenderTexture.Release();
+			RenderTexture.ReleaseTemporary(destRenderTexture);
 			if (Application.isEditor)
 			{
 				GameObject.DestroyImmediate(exportTexture);


### PR DESCRIPTION
As described in #226. When exporting to GLTF the Unity will warn about RenderTexture not being released correctly for each texture included in the expord:

`Releasing render texture that is set to be RenderTexture.active!`

The PR fixes the issue by using `RenderTexture.ReleaseTemporary(destRenderTexture)` instead of `destRenderTexture.Release()`.
