### PR TITLE
Throwing the exception after cleanup from SetUpLoad

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -2353,6 +2353,7 @@ namespace UnityGLTF
 			catch
 			{
 				Cleanup();
+				throw;
 			}
 			finally
 			{


### PR DESCRIPTION
Throwing the exception after cleanup from SetUpLoad to the caller method, so that it can be used later on