### PR TITLE
Remove O(N*M) asset reimports through importer.SaveAndReimport - 200x import speed improvement for test file

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFImporter.cs
@@ -279,8 +279,6 @@ namespace UnityGLTF
                                                 // Force disable sprite mode, even for 2D projects
                                                 importer.textureType = TextureImporterType.Default;
                                             }
-
-                                            //importer.SaveAndReimport();
                                         }
                                         else
                                         {

--- a/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFImporter.cs
@@ -211,6 +211,8 @@ namespace UnityGLTF
                         }
                     }
 
+					AssetDatabase.Refresh();
+
                     // Save materials as separate assets and rewrite refs
                     if (materials.Length > 0)
                     {
@@ -278,7 +280,7 @@ namespace UnityGLTF
                                                 importer.textureType = TextureImporterType.Default;
                                             }
 
-                                            importer.SaveAndReimport();
+                                            //importer.SaveAndReimport();
                                         }
                                         else
                                         {
@@ -289,7 +291,10 @@ namespace UnityGLTF
                             }
                         }
                     }
-                }
+
+					AssetDatabase.SaveAssets();
+					AssetDatabase.Refresh();
+				}
                 else
                 {
                     var temp = GameObject.CreatePrimitive(PrimitiveType.Plane);
@@ -309,6 +314,8 @@ namespace UnityGLTF
                 throw;
             }
 
+			
+
 #if UNITY_2017_3_OR_NEWER
 			// Set main asset
 			ctx.AddObjectToAsset("main asset", gltfScene);
@@ -316,7 +323,11 @@ namespace UnityGLTF
 			// Add meshes
 			foreach (var mesh in meshes)
 			{
-				ctx.AddObjectToAsset("mesh " + mesh.name, mesh);
+				try { 
+					ctx.AddObjectToAsset("mesh " + mesh.name, mesh);
+				} catch(System.InvalidOperationException e) {
+					Debug.LogWarning(e.ToString(), mesh);
+				}
 			}
 
 			ctx.SetMainObject(gltfScene);
@@ -327,12 +338,16 @@ namespace UnityGLTF
             // Add meshes
             foreach (var mesh in meshes)
             {
-                ctx.AddSubAsset("mesh " + mesh.name, mesh);
+                try {
+					ctx.AddSubAsset("mesh " + mesh.name, mesh);
+				} catch (System.InvalidOperationException e) {
+					Debug.LogWarning(e.ToString(), mesh);
+				}
             }
 #endif
-        }
+		}
 
-        private GameObject CreateGLTFScene(string projectFilePath)
+		private GameObject CreateGLTFScene(string projectFilePath)
         {
 			var importOptions = new ImportOptions
 			{


### PR DESCRIPTION
Currently, putting GLB files with a couple of textures into the project folder results in minute-long waits as the importer script has an inner loop calling TextureImporter.SaveAndReimport.

For a simple object (attached) with ~22 objects with about a texture each (some share textures), this results in crazy import times:
![191002-165621](https://user-images.githubusercontent.com/2693840/66059291-15ea8400-e53c-11e9-988d-8c526556f5b3.png)

This PR replaces those by a single call to AssetDatabase.SaveAssets and a subsequent AssetDatabase.Refresh, resulting in sub-second import times (down from > 200s before).
A 20.000% speed increase!

Additionally, this PR adds a try/catch around the AssetDatabase context add as that fails imports while it should actually only produce warnings.

This is the file to test this PR with:
[comp-20190923-174143.zip](https://github.com/KhronosGroup/UnityGLTF/files/3681972/comp-20190923-174143.zip)