### PR TITLE
Better handling of attribute errors

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Exceptions.cs
+++ b/GLTFSerialization/GLTFSerialization/Exceptions.cs
@@ -26,15 +26,15 @@ namespace GLTF
 #endif
 	}
 
-    public class GLTFLoadException : Exception
-    {
-        public GLTFLoadException() : base() { }
-        public GLTFLoadException(string message) : base(message) { }
-        public GLTFLoadException(string message, Exception inner) : base(message, inner) { }
+	public class GLTFLoadException : Exception
+	{
+		public GLTFLoadException() : base() { }
+		public GLTFLoadException(string message) : base(message) { }
+		public GLTFLoadException(string message, Exception inner) : base(message, inner) { }
 #if !WINDOWS_UWP
-        protected GLTFLoadException(System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context)
-        { }
+		protected GLTFLoadException(System.Runtime.Serialization.SerializationInfo info,
+			System.Runtime.Serialization.StreamingContext context)
+		{ }
 #endif
-    }
+	}
 }

--- a/GLTFSerialization/GLTFSerialization/Exceptions.cs
+++ b/GLTFSerialization/GLTFSerialization/Exceptions.cs
@@ -25,4 +25,16 @@ namespace GLTF
 		{ }
 #endif
 	}
+
+    public class GLTFLoadException : Exception
+    {
+        public GLTFLoadException() : base() { }
+        public GLTFLoadException(string message) : base(message) { }
+        public GLTFLoadException(string message, Exception inner) : base(message, inner) { }
+#if !WINDOWS_UWP
+        protected GLTFLoadException(System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context)
+        { }
+#endif
+    }
 }

--- a/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
+++ b/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
@@ -227,6 +227,7 @@ namespace GLTF
 		/// <param name="attributes">A list of attributes to parse</param>
 		public static void BuildMeshAttributes(ref Dictionary<string, AttributeAccessor> attributes)
 		{
+			List<string> unrecognizedAttributes = new List<string>();
 			foreach (var kvp in attributes)
 			{
 				var attributeAccessor = kvp.Value;
@@ -260,10 +261,20 @@ namespace GLTF
 						attributeAccessor.AccessorId.Value.AsUIntArray(ref resultArray, bufferViewCache, offset);
 						break;
 					default:
-						throw new System.Exception($"Unrecognized mesh attribute [{kvp.Key}]");
+						unrecognizedAttributes.Add(kvp.Key);
+						continue;
 				}
 				
 				attributeAccessor.AccessorContent = resultArray;
+			}
+
+			foreach (var attrib in unrecognizedAttributes) { 
+				attributes.Remove(attrib);
+			}
+
+			// TODO This should be a warning. Unrecognized attributes (e.g. TEXCOORD_4) should not cause full exceptions.
+			if (unrecognizedAttributes.Count > 0) {
+				throw new System.Exception($"Unrecognized mesh attributes [{string.Join(", ", unrecognizedAttributes.ToArray())}]");
 			}
 		}
 

--- a/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
+++ b/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
@@ -274,7 +274,7 @@ namespace GLTF
 
 			// TODO This should be a warning. Unrecognized attributes (e.g. TEXCOORD_4) should not cause full exceptions.
 			if (unrecognizedAttributes.Count > 0) {
-				throw new System.Exception($"Unrecognized mesh attributes [{string.Join(", ", unrecognizedAttributes.ToArray())}]");
+				throw new GLTFLoadException($"Unrecognized mesh attributes [{string.Join(", ", unrecognizedAttributes.ToArray())}]");
 			}
 		}
 

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
@@ -862,8 +862,11 @@ namespace UnityGLTF
 					Offset = (uint)bufferData.ChunkOffset
 				};
 			}
-
-			GLTFHelpers.BuildMeshAttributes(ref attributeAccessors);
+			try { 
+				GLTFHelpers.BuildMeshAttributes(ref attributeAccessors);
+			} catch (System.Exception e) {
+				Debug.LogWarning(e.ToString());
+			}
 			TransformAttributes(ref attributeAccessors);
 		}
 

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
@@ -864,7 +864,7 @@ namespace UnityGLTF
 			}
 			try { 
 				GLTFHelpers.BuildMeshAttributes(ref attributeAccessors);
-			} catch (System.Exception e) {
+			} catch (GLTFLoadException e) {
 				Debug.LogWarning(e.ToString());
 			}
 			TransformAttributes(ref attributeAccessors);


### PR DESCRIPTION
Instead of throwing when finding unrecognized attributes, this PR makes sure all attributes are collected and an exception is thrown after all are known. This allows to actually catch the exception and handle it per object instead of just failing.

Note that I did this because TEXCOORD_4 throws exceptions (it's not available in the attribute list) - not sure if this is a bug in itself.

A file to test this with is attached. I'm not entirely sure why it even has TEXCOORD_4, but with this PR the object imports just fine.
[wooden_eagle.zip](https://github.com/KhronosGroup/UnityGLTF/files/3682255/wooden_eagle.zip)
