### PR TITLE
Adding ability to get vertex count and triangle count from model load

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -140,6 +140,7 @@ namespace UnityGLTF
 					}
 				}
 
+				print("model loaded with vertices: " + sceneImporter.Statistics.VertexCount.ToString() + ", triangles: " + sceneImporter.Statistics.TriangleCount.ToString());
 				LastLoadedScene = sceneImporter.LastLoadedScene;
 
 				Animations = sceneImporter.LastLoadedScene.GetComponents<Animation>();

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -1634,7 +1634,7 @@ namespace UnityGLTF
 				var vertCount = primitive.Attributes[SemanticProperties.POSITION].Value.Count;
 				vertOffset += (int)vertCount;
 
-				if (unityData.Topology[i] == MeshTopology.Triangles)
+				if (unityData.Topology[i] == MeshTopology.Triangles && primitive.Indices != null && primitive.Indices.Value != null)
 				{
 					Statistics.TriangleCount += primitive.Indices.Value.Count / 3;
 				}

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -82,6 +82,12 @@ namespace UnityGLTF
 		}
 	}
 
+	public struct ImportStatistics
+	{
+		public long TriangleCount;
+		public long VertexCount;
+	}
+
 	/// <summary>
 	/// Converts gltf animation data to unity
 	/// </summary>
@@ -165,6 +171,11 @@ namespace UnityGLTF
 		/// When screen coverage is above threashold and no LOD mesh cull the object
 		/// </summary>
 		public bool CullFarLOD = false;
+
+		/// <summary>
+		/// Statistics from the scene
+		/// </summary>
+		public ImportStatistics Statistics;
 
 		protected struct GLBStream
 		{
@@ -280,6 +291,8 @@ namespace UnityGLTF
 
 				this.progressStatus = new ImportProgress();
 				this.progress = progress;
+
+				Statistics = new ImportStatistics();
 				progress?.Report(progressStatus);
 
 				if (_gltfRoot == null)
@@ -1620,8 +1633,14 @@ namespace UnityGLTF
 
 				var vertCount = primitive.Attributes[SemanticProperties.POSITION].Value.Count;
 				vertOffset += (int)vertCount;
+
+				if (unityData.Topology[i] == MeshTopology.Triangles)
+				{
+					Statistics.TriangleCount += primitive.Indices.Value.Count / 3;
+				}
 			}
 
+			Statistics.VertexCount += vertOffset;
 			await ConstructUnityMesh(unityData, meshIndex, mesh.Name);
 		}
 
@@ -2333,6 +2352,7 @@ namespace UnityGLTF
 					_isRunning = true;
 				}
 
+				Statistics = new ImportStatistics();
 				if (_options.ThrowOnLowMemory)
 				{
 					_memoryChecker = new MemoryChecker();


### PR DESCRIPTION
- Vertex count and triangle count not gotten after load from Statistics on GLTFSceneImporter
- TriangleCount only accurate for meshes that have indices and a triangle topology