### PR TITLE
Added CHANGELOG.md with info from releases page

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/CHANGELOG.md
+++ b/UnityGLTF/Assets/UnityGLTF/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2019-04-03
+- Upgraded to 2017.4
+- Included various fixes (will update)
+- Includes UPM package
+
+## [1.0.0] - 2018-09-21
+- first built unity package release of UnityGLTF

--- a/UnityGLTF/Assets/UnityGLTF/CHANGELOG.md.meta
+++ b/UnityGLTF/Assets/UnityGLTF/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2ac567cb9b76e6a4490f2f54aa52c067
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
UPM packages should have a CHANGELOG; this PR adds one in the right place with the information from the releases page. This should be updated on each package release.