### PR TITLE
Update GLTFImporter.cs

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFImporter.cs
@@ -316,7 +316,14 @@ namespace UnityGLTF
 			// Add meshes
 			foreach (var mesh in meshes)
 			{
-				ctx.AddObjectToAsset("mesh " + mesh.name, mesh);
+				try
+                {
+                    ctx.AddObjectToAsset("mesh " + mesh.name, mesh);
+                }
+                catch (InvalidOperationException e)
+                {
+                    Debug.LogWarning(e);
+                }
 			}
 
 			ctx.SetMainObject(gltfScene);
@@ -327,7 +334,14 @@ namespace UnityGLTF
             // Add meshes
             foreach (var mesh in meshes)
             {
-                ctx.AddSubAsset("mesh " + mesh.name, mesh);
+				try
+                {
+					ctx.AddSubAsset("mesh " + mesh.name, mesh);
+				}
+				catch (InvalidOperationException e)
+                {
+                    Debug.LogWarning(e);
+                }
             }
 #endif
         }


### PR DESCRIPTION
Importing a model that reuses an instance of a mesh several times will throw an InvalidOperationException. This renders the asset invalid (no import settings show up). Skipping this error with try/catch leaves no errors.