### PR TITLE
Exporter GLB byte alignment for buffer

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -201,7 +201,7 @@ namespace UnityGLTF
 
 			_root.Scene = ExportScene(sceneName, _rootTransforms);
 
-			_buffer.ByteLength = (uint)_bufferWriter.BaseStream.Length;
+			_buffer.ByteLength = CalculateAlignment((uint)_bufferWriter.BaseStream.Length, 4);
 
 			_root.Serialize(jsonWriter, true);
 


### PR DESCRIPTION
Correcting the GLB export logic to report a byte-aligned size for the main buffer.  This did not normally cause a problem because the last thing written was usually a texture, which was already made to be a 4-byte multiple and then started at a 4-byte offset, but on models without textures this was easy to hit.

Also updating to the latest sample models which includes the MetalRoughnessSpheresNoTextures model that reprod this bug.