### PR TITLE
Mark asmdef as used for Testing

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Tests/UnityGLTFTests.asmdef
+++ b/UnityGLTF/Assets/UnityGLTF/Tests/UnityGLTFTests.asmdef
@@ -1,5 +1,8 @@
 {
     "name": "UnityGLTFTests",
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
     "references": [
         "UnityGLTFScripts",
         "UnityGLTFEditor"


### PR DESCRIPTION
For some reason the Tests folder asmdef wasn't marked as test assembly for me; this results in compiler errors. This PR fixes that.