### PR TITLE
Respect _EMISSION and _NORMALMAP material keywords

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -851,33 +851,35 @@ namespace UnityGLTF
 
 			material.DoubleSided = materialObj.HasProperty("_Cull") &&
 				materialObj.GetInt("_Cull") == (float)CullMode.Off;
-				
-			if (materialObj.HasProperty("_EmissionColor"))
-			{
-				material.EmissiveFactor = materialObj.GetColor("_EmissionColor").ToNumericsColorRaw();
-			}
 
-			if (materialObj.HasProperty("_EmissionMap"))
-			{
-				var emissionTex = materialObj.GetTexture("_EmissionMap");
-
-				if (emissionTex != null)
+			if(materialObj.IsKeywordEnabled("_EMISSION"))
+			{ 
+				if (materialObj.HasProperty("_EmissionColor"))
 				{
-					if(emissionTex is Texture2D)
-					{
-						material.EmissiveTexture = ExportTextureInfo(emissionTex, TextureMapType.Emission);
+					material.EmissiveFactor = materialObj.GetColor("_EmissionColor").ToNumericsColorRaw();
+				}
 
-						ExportTextureTransform(material.EmissiveTexture, materialObj, "_EmissionMap");
-					}
-					else
-					{
-						Debug.LogErrorFormat("Can't export a {0} emissive texture in material {1}", emissionTex.GetType(), materialObj.name);
-					}
+				if (materialObj.HasProperty("_EmissionMap"))
+				{
+					var emissionTex = materialObj.GetTexture("_EmissionMap");
 
+					if (emissionTex != null)
+					{
+						if(emissionTex is Texture2D)
+						{
+							material.EmissiveTexture = ExportTextureInfo(emissionTex, TextureMapType.Emission);
+
+							ExportTextureTransform(material.EmissiveTexture, materialObj, "_EmissionMap");
+						}
+						else
+						{
+							Debug.LogErrorFormat("Can't export a {0} emissive texture in material {1}", emissionTex.GetType(), materialObj.name);
+						}
+
+					}
 				}
 			}
-
-			if (materialObj.HasProperty("_BumpMap"))
+			if (materialObj.HasProperty("_BumpMap") && materialObj.IsKeywordEnabled("_NORMALMAP"))
 			{
 				var normalTex = materialObj.GetTexture("_BumpMap");
 


### PR DESCRIPTION
Currently, emission is exported based on the fact that an emission texture and/or color has been assigned.

This means that enabling emission, adding a texture and color, and then disabling emission resulted in the exported file still having emission active.

This PR properly respects the actual shader keyword that is set by Unity when the "Emission" checkbox is toggled on - _EMISSION.
Additionally, it does the same for the _NORMALMAP keyword.