### PR TITLE
Correctly release temp RT

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -1335,7 +1335,8 @@ namespace UnityGLTF
 			var pngImageData = exportTexture.EncodeToPNG();
 			_bufferWriter.Write(pngImageData);
 
-			destRenderTexture.Release();
+			RenderTexture.ReleaseTemporary(destRenderTexture);
+
 			GL.sRGBWrite = false;
 			if (Application.isEditor)
 			{


### PR DESCRIPTION
Prevents console warning on every exported texture. RTs allocated with GetTemporary should be released with ReleaseTemporary.