### PR TITLE
Export existing PNG/JPG textures from disk if available

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFExportMenu.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFExportMenu.cs
@@ -24,6 +24,7 @@ public class GLTFExportMenu : EditorWindow
         GLTFSceneExporter.ExportFullPath = EditorGUILayout.Toggle("Export using original path", GLTFSceneExporter.ExportFullPath);
         GLTFSceneExporter.ExportNames = EditorGUILayout.Toggle("Export names of nodes", GLTFSceneExporter.ExportNames);
         GLTFSceneExporter.RequireExtensions= EditorGUILayout.Toggle("Require extensions", GLTFSceneExporter.RequireExtensions);
+        GLTFSceneExporter.TryExportTexturesFromDisk = EditorGUILayout.Toggle("Try to export textures from disk", GLTFSceneExporter.TryExportTexturesFromDisk);
         EditorGUILayout.Separator();
         EditorGUILayout.LabelField("Importer", EditorStyles.boldLabel);
         EditorGUILayout.Separator();

--- a/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFExportMenu.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFExportMenu.cs
@@ -45,7 +45,7 @@ public class GLTFExportMenu : EditorWindow
 		var exportOptions = new ExportOptions { TexturePathRetriever = RetrieveTexturePath };
 		var exporter = new GLTFSceneExporter(Selection.transforms, exportOptions);
 
-		var path = EditorUtility.OpenFolderPanel("glTF Export Path", "", "");
+		var path = EditorUtility.SaveFolderPanel("glTF Export Path", "", "");
 		if (!string.IsNullOrEmpty(path)) {
 			exporter.SaveGLTFandBin (path, name);
 		}
@@ -65,7 +65,7 @@ public class GLTFExportMenu : EditorWindow
 		var exportOptions = new ExportOptions { TexturePathRetriever = RetrieveTexturePath };
 		var exporter = new GLTFSceneExporter(Selection.transforms, exportOptions);
 
-		var path = EditorUtility.OpenFolderPanel("glTF Export Path", "", "");
+		var path = EditorUtility.SaveFolderPanel("glTF Export Path", "", "");
 		if (!string.IsNullOrEmpty(path))
 		{
 			exporter.SaveGLB(path, name);
@@ -81,7 +81,7 @@ public class GLTFExportMenu : EditorWindow
 
 		var exportOptions = new ExportOptions { TexturePathRetriever = RetrieveTexturePath };
 		var exporter = new GLTFSceneExporter(transforms, exportOptions);
-		var path = EditorUtility.OpenFolderPanel("glTF Export Path", "", "");
+		var path = EditorUtility.SaveFolderPanel("glTF Export Path", "", "");
 		if (path != "") {
 			exporter.SaveGLTFandBin (path, scene.name);
 		}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -83,6 +83,7 @@ namespace UnityGLTF
 		public static bool ExportNames = true;
 		public static bool ExportFullPath = true;
 		public static bool RequireExtensions = false;
+		public static bool TryExportTexturesFromDisk = true;
 
 		/// <summary>
 		/// Create a GLTFExporter that exports out a transform
@@ -323,7 +324,7 @@ namespace UnityGLTF
 			{
 				var image = _imageInfos[t].texture;
 
-				if (TryGetTextureDataFromDisk(image, out string path, out byte[] imageBytes))
+				if (TryExportTexturesFromDisk && TryGetTextureDataFromDisk(image, out string path, out byte[] imageBytes))
 				{
 					var finalFilenamePath = ConstructImageFilenamePath(image, outputPath);
 					finalFilenamePath = Path.ChangeExtension(finalFilenamePath, Path.GetExtension(path));
@@ -1357,7 +1358,7 @@ namespace UnityGLTF
 
 			bool wasAbleToExportFromDisk = false;
 
-			if(TryGetTextureDataFromDisk(texture, out string path, out byte[] imageBytes))
+			if(TryExportTexturesFromDisk && TryGetTextureDataFromDisk(texture, out string path, out byte[] imageBytes))
 			{ 
 				if(IsPng(path))
 				{
@@ -1373,7 +1374,7 @@ namespace UnityGLTF
 				}
 			}
 
-			if(!wasAbleToExportFromDisk)
+			if(!TryExportTexturesFromDisk && !wasAbleToExportFromDisk)
 		    {
 				image.MimeType = "image/png";
 


### PR DESCRIPTION
Currently, textures are always encoded as PNG files on export. This is desirable in a lot of situations (e.g. textures only exist in memory, render textures, ...), but in some cases the existing files from disk should be used (namely, if the textures on disk inside the Unity project are already compressed and prepared for GLTF/GLB workflow).

This PR adds an option to try to use the textures from disk into the settings window.
What would you think is the better default - off (current behaviour) or on (new behaviour)? (I'm favoring "on - export png and jpg from disk by default").