### PR TITLE
Change flip texture coordinates with flip texture

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -1078,7 +1078,7 @@ namespace UnityGLTF
 				def.Extensions = new Dictionary<string, IExtension>();
 
 			def.Extensions[ExtTextureTransformExtensionFactory.EXTENSION_NAME] = new ExtTextureTransformExtension(
-				new GLTF.Math.Vector2(offset.x, -offset.y),
+				new GLTF.Math.Vector2(offset.x, offset.y),
 				0, // TODO: support rotation
 				new GLTF.Math.Vector2(scale.x, scale.y),
 				0 // TODO: support UV channels


### PR DESCRIPTION
Better not to flip the texture coordinates. If uv* represents something else other than coordinates, we cannot simply perform 1 - uv*.y on it.
