### PR TITLE
KHR_materials_pbrSpecularGlossiness export support

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_pbrSpecularGlossinessExtension.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_pbrSpecularGlossinessExtension.cs
@@ -14,9 +14,6 @@ namespace GLTF.Schema
 	/// </summary>
 	public class KHR_materials_pbrSpecularGlossinessExtension : IExtension
 	{
-		public static readonly Vector3 SPEC_FACTOR_DEFAULT = new Vector3(0.2f, 0.2f, 0.2f);
-		public static readonly double GLOSS_FACTOR_DEFAULT = 0.5d; 
-
 		/// <summary>
 		/// The RGBA components of the reflected diffuse color of the material. 
 		/// Metals have a diffuse value of [0.0, 0.0, 0.0]. 
@@ -25,6 +22,7 @@ namespace GLTF.Schema
 		/// The values are linear.
 		/// </summary>
 		public Color DiffuseFactor = Color.White;
+		public static readonly Color DIFFUSE_FACTOR_DEFAULT = Color.White;
 
 		/// <summary>
 		/// The diffuse texture. 
@@ -35,11 +33,13 @@ namespace GLTF.Schema
 		/// The stored texels must not be premultiplied.
 		/// </summary>
 		public TextureInfo DiffuseTexture;
+		public static readonly TextureInfo DIFFUSE_TEXTURE_DEFAULT = new TextureInfo();
 
 		/// <summary>
 		/// The specular RGB color of the material. This value is linear
 		/// </summary>
 		public Vector3 SpecularFactor = SPEC_FACTOR_DEFAULT;
+		public static readonly Vector3 SPEC_FACTOR_DEFAULT = new Vector3(0.2f, 0.2f, 0.2f);
 
 		/// <summary>
 		/// The glossiness or smoothness of the material. 
@@ -48,12 +48,14 @@ namespace GLTF.Schema
 		/// This value is linear.
 		/// </summary>
 		public double GlossinessFactor = GLOSS_FACTOR_DEFAULT;
+		public static readonly double GLOSS_FACTOR_DEFAULT = 0.5d;
 
 		/// <summary>
 		/// The specular-glossiness texture is RGBA texture, containing the specular color of the material (RGB components) and its glossiness (A component). 
 		/// The values are in sRGB space.
 		/// </summary>
 		public TextureInfo SpecularGlossinessTexture;
+		public static readonly TextureInfo SPECULAR_GLOSSINESS_TEXTURE_DEFAULT = new TextureInfo();
 
 		public KHR_materials_pbrSpecularGlossinessExtension(Color diffuseFactor, TextureInfo diffuseTexture, Vector3 specularFactor, double glossinessFactor, TextureInfo specularGlossinessTexture)
 		{

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -918,6 +918,10 @@ namespace UnityGLTF
 			{
 				material.PbrMetallicRoughness = ExportPBRMetallicRoughness(materialObj);
 			}
+			else if (IsPBRSpecularGlossiness(materialObj))
+			{
+				ExportPBRSpecularGlossiness(material, materialObj);
+			}
 			else if (IsCommonConstant(materialObj))
 			{
 				material.CommonConstant = ExportCommonConstant(materialObj);
@@ -988,6 +992,11 @@ namespace UnityGLTF
 		private bool IsPBRMetallicRoughness(Material material)
 		{
 			return material.HasProperty("_Metallic") && material.HasProperty("_MetallicGlossMap");
+		}
+
+		private bool IsPBRSpecularGlossiness(Material material)
+		{
+			return material.HasProperty("_SpecColor") && material.HasProperty("_SpecGlossMap");
 		}
 
 		private bool IsCommonConstant(Material material)
@@ -1130,25 +1139,111 @@ namespace UnityGLTF
 					}
 				}
 			}
-			else if (material.HasProperty("_SpecGlossMap"))
-			{
-				var mgTex = material.GetTexture("_SpecGlossMap");
 
-				if (mgTex != null)
+			return pbr;
+		}
+
+		private void ExportPBRSpecularGlossiness(GLTFMaterial material, Material materialObj)
+		{
+			if (_root.ExtensionsUsed == null)
+			{
+				_root.ExtensionsUsed = new List<string>(new[] { "KHR_materials_pbrSpecularGlossiness" });
+			}
+			else if (!_root.ExtensionsUsed.Contains("KHR_materials_pbrSpecularGlossiness"))
+			{
+				_root.ExtensionsUsed.Add("KHR_materials_pbrSpecularGlossiness");
+			}
+
+			if (RequireExtensions)
+			{
+				if (_root.ExtensionsRequired == null)
 				{
-					if(mgTex is Texture2D)
+					_root.ExtensionsRequired = new List<string>(new[] { "KHR_materials_pbrSpecularGlossiness" });
+				}
+				else if (!_root.ExtensionsRequired.Contains("KHR_materials_pbrSpecularGlossiness"))
+				{
+					_root.ExtensionsRequired.Add("KHR_materials_pbrSpecularGlossiness");
+				}
+			}
+
+			if (material.Extensions == null)
+			{
+				material.Extensions = new Dictionary<string, IExtension>();
+			}
+
+			GLTF.Math.Color diffuseFactor = KHR_materials_pbrSpecularGlossinessExtension.DIFFUSE_FACTOR_DEFAULT;
+			TextureInfo diffuseTexture = KHR_materials_pbrSpecularGlossinessExtension.DIFFUSE_TEXTURE_DEFAULT;
+			GLTF.Math.Vector3 specularFactor = KHR_materials_pbrSpecularGlossinessExtension.SPEC_FACTOR_DEFAULT;
+			double glossinessFactor = KHR_materials_pbrSpecularGlossinessExtension.GLOSS_FACTOR_DEFAULT;
+			TextureInfo specularGlossinessTexture = KHR_materials_pbrSpecularGlossinessExtension.SPECULAR_GLOSSINESS_TEXTURE_DEFAULT;
+
+			if (materialObj.HasProperty("_Color"))
+			{
+				diffuseFactor = materialObj.GetColor("_Color").ToNumericsColorRaw();
+			}
+
+			if (materialObj.HasProperty("_MainTex"))
+			{
+				var mainTex = materialObj.GetTexture("_MainTex");
+
+				if (mainTex != null)
+				{
+					if (mainTex is Texture2D)
 					{
-						pbr.MetallicRoughnessTexture = ExportTextureInfo(mgTex, TextureMapType.SpecGloss);
-						ExportTextureTransform(pbr.MetallicRoughnessTexture, material, "_SpecGlossMap");
+						diffuseTexture = ExportTextureInfo(mainTex, TextureMapType.Main);
+						ExportTextureTransform(diffuseTexture, materialObj, "_MainTex");
 					}
 					else
 					{
-						Debug.LogErrorFormat("Can't export a {0} metallic roughness texture in material {1}", mgTex.GetType(), material.name);
+						Debug.LogErrorFormat("Can't export a {0} diffuse texture in material {1}", mainTex.GetType(), materialObj.name);
 					}
 				}
 			}
 
-			return pbr;
+			if (materialObj.HasProperty("_SpecColor"))
+			{
+				var specGlossMap = materialObj.GetTexture("_SpecGlossMap");
+				if (specGlossMap == null)
+				{
+					Color specColor = materialObj.GetColor("_SpecColor");
+					specularFactor = new GLTF.Math.Vector3(specColor.r, specColor.g, specColor.b);
+				}
+			}
+
+			if (materialObj.HasProperty("_Glossiness"))
+			{
+				var specGlossMap = materialObj.GetTexture("_SpecGlossMap");
+				if (specGlossMap == null)
+				{
+					glossinessFactor = materialObj.GetFloat("_Glossiness");
+				}
+			}
+
+			if (materialObj.HasProperty("_SpecGlossMap"))
+			{
+				var mgTex = materialObj.GetTexture("_SpecGlossMap");
+
+				if (mgTex != null)
+				{
+					if (mgTex is Texture2D)
+					{
+						specularGlossinessTexture = ExportTextureInfo(mgTex, TextureMapType.SpecGloss);
+						ExportTextureTransform(specularGlossinessTexture, materialObj, "_SpecGlossMap");
+					}
+					else
+					{
+						Debug.LogErrorFormat("Can't export a {0} specular glossiness texture in material {1}", mgTex.GetType(), materialObj.name);
+					}
+				}
+			}
+
+			material.Extensions[KHR_materials_pbrSpecularGlossinessExtensionFactory.EXTENSION_NAME] = new KHR_materials_pbrSpecularGlossinessExtension(
+				diffuseFactor,
+				diffuseTexture,
+				specularFactor,
+				glossinessFactor,
+				specularGlossinessTexture
+			);
 		}
 
 		private MaterialCommonConstant ExportCommonConstant(Material materialObj)


### PR DESCRIPTION
Add exporting KHR_materials_pbrSpecularGlossiness. To close the issue [#539](https://github.com/KhronosGroup/UnityGLTF/issues/539).