### PR TITLE
Add extension FB_materials_modmap to support the export of lightmap

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Extensions/FB_materials_modmapExtension.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/FB_materials_modmapExtension.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using GLTF.Math;
+using GLTF.Schema;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GLTF.Schema
+{
+	public class FB_materials_modmapExtension : IExtension
+	{
+		/// <summary>
+		/// A 3-component vector describing the attenuation of the modmap before baseColor application.
+		/// </summary>
+		public Vector3 ModmapFactor = MODMAP_FACTOR_DEFAULT;
+		public static readonly Vector3 MODMAP_FACTOR_DEFAULT = new Vector3(1.0f, 1.0f, 1.0f);
+
+		/// <summary>
+		/// The modmap texture.
+		/// This texture contains RGB components of the modmap data of the material in sRGB color space.  
+		/// </summary>
+		public TextureInfo ModmapTexture;
+		public static readonly TextureInfo MODMAP_TEXTURE_DEFAULT = new TextureInfo();
+
+
+		public FB_materials_modmapExtension(
+			Vector3 modmapFactor,
+			TextureInfo modmapTexture)
+		{
+			ModmapFactor = modmapFactor;
+			ModmapTexture = modmapTexture;
+		}
+
+		public IExtension Clone(GLTFRoot gltfRoot)
+		{
+			return new FB_materials_modmapExtension(
+				ModmapFactor,
+				new TextureInfo(
+					ModmapTexture,
+					gltfRoot
+				));
+		}
+
+		public JProperty Serialize()
+		{
+			JObject ext = new JObject();
+
+			if (ModmapFactor != MODMAP_FACTOR_DEFAULT)
+			{
+				ext.Add(new JProperty(
+					FB_materials_modmapExtensionFactory.MODMAP_FACTOR,
+					new JArray(ModmapFactor.X, ModmapFactor.Y, ModmapFactor.Z)
+				));
+			}
+
+			if (ModmapTexture != null)
+			{
+				ext.Add(new JProperty(
+					FB_materials_modmapExtensionFactory.MODMAP_TEXTURE,
+						new JObject(
+							new JProperty(TextureInfo.INDEX, ModmapTexture.Index.Id)
+						)
+					)
+				);
+			}
+
+			return new JProperty(FB_materials_modmapExtensionFactory.EXTENSION_NAME, ext);
+		}
+	}
+}

--- a/GLTFSerialization/GLTFSerialization/Extensions/FB_materials_modmapExtension.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/FB_materials_modmapExtension.cs
@@ -18,7 +18,7 @@ namespace GLTF.Schema
 		/// The modmap texture.
 		/// This texture contains RGB components of the modmap data of the material in sRGB color space.  
 		/// </summary>
-		public TextureInfo ModmapTexture;
+		public TextureInfo ModmapTexture = MODMAP_TEXTURE_DEFAULT;
 		public static readonly TextureInfo MODMAP_TEXTURE_DEFAULT = new TextureInfo();
 
 
@@ -52,7 +52,7 @@ namespace GLTF.Schema
 				));
 			}
 
-			if (ModmapTexture != null)
+			if (ModmapTexture != MODMAP_TEXTURE_DEFAULT)
 			{
 				ext.Add(new JProperty(
 					FB_materials_modmapExtensionFactory.MODMAP_TEXTURE,

--- a/GLTFSerialization/GLTFSerialization/Extensions/FB_materials_modmapExtensionFactory.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/FB_materials_modmapExtensionFactory.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json.Linq;
+using GLTF.Extensions;
+using GLTF.Math;
+
+namespace GLTF.Schema
+{
+	public class FB_materials_modmapExtensionFactory : ExtensionFactory
+	{
+		public const string EXTENSION_NAME = "FB_materials_modmap";
+
+		public const string MODMAP_FACTOR = "modmapFactor";
+		public const string MODMAP_TEXTURE = "modmapTexture";
+
+
+		public FB_materials_modmapExtensionFactory()
+		{
+			ExtensionName = EXTENSION_NAME;
+		}
+
+		public override IExtension Deserialize(GLTFRoot root, JProperty extensionToken)
+		{
+			Vector3 modmapFactor = FB_materials_modmapExtension.MODMAP_FACTOR_DEFAULT;
+			TextureInfo modmapTexture = FB_materials_modmapExtension.MODMAP_TEXTURE_DEFAULT;
+
+			if (extensionToken != null)
+			{
+				JToken modmapFactorToken = extensionToken.Value[MODMAP_FACTOR];
+				modmapFactor = modmapFactorToken != null ? modmapFactorToken.DeserializeAsVector3() : modmapFactor;
+
+				JToken modmapTextureToken = extensionToken.Value[MODMAP_TEXTURE];
+				modmapTexture = modmapTextureToken != null ? modmapTextureToken.DeserializeAsTexture(root) : modmapTexture;
+			}
+			
+			return new FB_materials_modmapExtension(modmapFactor, modmapTexture);
+		}
+	}
+}

--- a/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
@@ -114,6 +114,22 @@ namespace GLTF.Extensions
 			return textureInfo;
 		}
 
+		public static bool DeserializeAsBool(this JToken token)
+		{
+			if (token != null)
+			{
+				JValue boolValue = token as JValue;
+				if (boolValue == null)
+				{
+					throw new Exception("JToken used for bool deserialization was not a JValue. It was a " + token.Type.ToString());
+				}
+
+				return (bool)boolValue;
+			}
+
+			return false;
+		}
+
 		public static int DeserializeAsInt(this JToken token)
 		{
 			if (token != null)
@@ -130,6 +146,22 @@ namespace GLTF.Extensions
 			return 0;
 		}
 
+		public static float DeserializeAsFloat(this JToken token)
+		{
+			if (token != null)
+			{
+				JValue floatValue = token as JValue;
+				if (floatValue == null)
+				{
+					throw new Exception("JToken used for float deserialization was not a JValue. It was a " + token.Type.ToString());
+				}
+
+				return (float)floatValue;
+			}
+
+			return 0.0f;
+		}
+
 		public static double DeserializeAsDouble(this JToken token)
 		{
 			if (token != null)
@@ -144,6 +176,22 @@ namespace GLTF.Extensions
 			}
 
 			return 0d;
+		}
+
+		public static string DeserializeAsString(this JToken token)
+		{
+			if (token != null)
+			{
+				JValue stringValue = token as JValue;
+				if (stringValue == null)
+				{
+					throw new Exception("JToken used for string deserialization was not a JValue. It was a " + token.Type.ToString());
+				}
+
+				return (string)stringValue;
+			}
+
+			return "";
 		}
 
 		public static Color ReadAsRGBAColor(this JsonReader reader)

--- a/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtension.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtension.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using GLTF.Math;
+using GLTF.Schema;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GLTF.Schema
+{
+	public class KHR_materials_commonExtension : IExtension
+	{
+		public enum CommonTechnique
+		{
+			NONE = -1,
+			CONSTANT,
+			LAMBERT,
+			PHONG,
+			BLINN
+		}
+
+		/// <summary>
+		/// Specifies the shading technique used e.g.BLINN, and values which contains a set of technique-specific values.
+		/// </summary>
+		public CommonTechnique Technique = CommonTechnique.CONSTANT;
+		public static readonly CommonTechnique TECHNIQUE_DEFAULT = CommonTechnique.NONE;
+
+		/// <summary>
+		/// RGBA value for ambient light reflected from the surface of the object.
+		/// </summary>
+		public Color Ambient = Color.Black;
+		public static readonly Color AMBIENT_DEFAULT = Color.Black;
+
+		/// <summary>
+		/// RGBA value for light emitted by the surface of the object.
+		/// </summary>
+		public Color EmissionColor = Color.Black;
+		public static readonly Color EMISSIONCOLOR_DEFAULT = Color.Black;
+
+		/// <summary>
+		/// Texture for light emitted by the surface of the object.
+		/// </summary>
+		public TextureInfo EmissionTexture;
+		public static readonly TextureInfo EMISSIONTEXTURE_DEFAULT = new TextureInfo();
+
+		/// <summary>
+		/// RGBA value defining the amount of light diffusely reflected from the surface of the object.
+		/// </summary>
+		public Color DiffuseColor = Color.Black;
+		public static readonly Color DIFFUSECOLOR_DEFAULT = Color.Black;
+
+		/// <summary>
+		/// Texture defining the amount of light diffusely reflected from the surface of the object.
+		/// </summary>
+		public TextureInfo DiffuseTexture;
+		public static readonly TextureInfo DIFFUSETEXTURE_DEFAULT = new TextureInfo();
+
+		/// <summary>
+		/// RGBA value defining the color of light specularly reflected from the surface of the object.
+		/// </summary>
+		public Color SpecularColor = Color.Black;
+		public static readonly Color SPECULARCOLOR_DEFAULT = Color.Black;
+
+		/// <summary>
+		/// Texture defining the color of light specularly reflected from the surface of the object.
+		/// </summary>
+		public TextureInfo SpecularTexture;
+		public static readonly TextureInfo SPECULARTEXTURE_DEFAULT = new TextureInfo();
+
+		/// <summary>
+		/// Defines the specularity or roughness of the specular reflection lobe of the object.
+		/// </summary>
+		public float Shininess = 0.0f;
+		public static readonly float SHININESS_DEFAULT = 0.0f;
+
+		/// <summary>
+		/// Declares the amount of transparency as an opacity value between 0.0 and 1.0.
+		/// </summary>
+		public float Transparency = 1.0f;
+		public static readonly float TRANSPARENCY_DEFAULT = 1.0f;
+
+		/// <summary>
+		/// Declares whether the visual should be rendered using alpha blending.
+		/// Corresponds to enabling the BLEND render state, setting the depthMask property to false,
+		/// and defining blend equations and blend functions as described in the implementation note.
+		/// </summary>
+		public bool Transparent = false;
+		public static readonly bool TRANSPARENT_DEFAULT = false;
+
+		/// <summary>
+		/// Declares whether backface culling should be disabled for this visual. Corresponds to disabling the CULL_FACE render state.
+		/// </summary>
+		public bool DoubleSided = false;
+		public static readonly bool DOUBLESIDED_DEFAULT = false;
+
+
+		public KHR_materials_commonExtension(
+			CommonTechnique technique,
+			Color ambient,
+			Color emissionColor,
+			TextureInfo emissionTexture,
+			Color diffuseColor,
+			TextureInfo diffuseTexture,
+			Color specularColor,
+			TextureInfo specularTexture,
+			float shininess,
+			float transparency,
+			bool transparent,
+			bool doubleSided)
+		{
+			Technique = technique;
+			Ambient = ambient;
+			EmissionColor = emissionColor;
+			EmissionTexture = emissionTexture;
+			DiffuseColor = diffuseColor;
+			DiffuseTexture = diffuseTexture;
+			SpecularColor = specularColor;
+			SpecularTexture = specularTexture;
+			Shininess = shininess;
+			Transparency = transparency;
+			Transparent = transparent;
+			DoubleSided = doubleSided;
+		}
+
+		public IExtension Clone(GLTFRoot gltfRoot)
+		{
+			return new KHR_materials_commonExtension(
+				Technique, Ambient, EmissionColor,
+				new TextureInfo(
+					EmissionTexture,
+					gltfRoot
+				),
+				DiffuseColor,
+				new TextureInfo(
+					DiffuseTexture,
+					gltfRoot
+				),
+				SpecularColor,
+				new TextureInfo(
+					SpecularTexture,
+					gltfRoot
+				),
+				Shininess, Transparency, Transparent, DoubleSided);
+		}
+
+		public JProperty Serialize()
+		{
+			if(CommonTechnique.NONE == Technique)
+			{
+				return new JProperty("", new JObject());
+			}
+
+			JObject ext = new JObject();
+
+			ext.Add(new JProperty(
+				KHR_materials_commonExtensionFactory.TECHNIQUE,
+				Technique.ToString()
+			));
+
+			var valuesObj = new JObject();
+			ext.Add(new JProperty(
+				KHR_materials_commonExtensionFactory.VALUES,
+				valuesObj)
+			);
+
+			if (Ambient != AMBIENT_DEFAULT)
+			{
+				valuesObj.Add(new JProperty(
+					KHR_materials_commonExtensionFactory.AMBIENT,
+					new JArray(Ambient.R, Ambient.G, Ambient.B)
+				));
+			}
+
+			if (EmissionTexture != null)
+			{
+				valuesObj.Add(new JProperty(
+					KHR_materials_commonExtensionFactory.EMISSION,
+						new JObject(
+							new JProperty(TextureInfo.INDEX, EmissionTexture.Index.Id)
+						)
+					)
+				);
+			}
+			else
+			{
+				if (EmissionColor != EMISSIONCOLOR_DEFAULT)
+				{
+					valuesObj.Add(new JProperty(
+						KHR_materials_commonExtensionFactory.EMISSION,
+						new JArray(EmissionColor.R, EmissionColor.G, EmissionColor.B)
+					));
+				}
+			}
+
+			if (Technique == CommonTechnique.LAMBERT ||
+				Technique == CommonTechnique.PHONG ||
+				Technique == CommonTechnique.BLINN ||
+				Technique == CommonTechnique.CONSTANT)
+			{
+				if (DiffuseTexture != null)
+				{
+					valuesObj.Add(new JProperty(
+						KHR_materials_commonExtensionFactory.DIFFUSE,
+							new JObject(
+								new JProperty(TextureInfo.INDEX, DiffuseTexture.Index.Id)
+							)
+						)
+					);
+				}
+				else
+				{
+					if (DiffuseColor != DIFFUSECOLOR_DEFAULT)
+					{
+						valuesObj.Add(new JProperty(
+							KHR_materials_commonExtensionFactory.DIFFUSE,
+							new JArray(DiffuseColor.R, DiffuseColor.G, DiffuseColor.B)
+						));
+					}
+				}
+			}
+
+			if (Technique == CommonTechnique.PHONG ||
+				Technique == CommonTechnique.BLINN)
+			{
+				if (SpecularTexture != null)
+				{
+					valuesObj.Add(new JProperty(
+						KHR_materials_commonExtensionFactory.SPECULAR,
+							new JObject(
+								new JProperty(TextureInfo.INDEX, SpecularTexture.Index.Id)
+							)
+						)
+					);
+				}
+				else
+				{
+					if (SpecularColor != Color.Black)
+					{
+						if (SpecularColor != SPECULARCOLOR_DEFAULT)
+						{
+							valuesObj.Add(new JProperty(
+								KHR_materials_commonExtensionFactory.SPECULAR,
+								new JArray(SpecularColor.R, SpecularColor.G, SpecularColor.B)
+							));
+						}
+					}
+				}
+
+				if (Shininess != SHININESS_DEFAULT)
+				{
+					valuesObj.Add(new JProperty(
+						KHR_materials_commonExtensionFactory.SHININESS,
+						Shininess
+					));
+				}
+			}
+
+			if (Transparency != TRANSPARENCY_DEFAULT)
+			{
+				valuesObj.Add(new JProperty(
+					KHR_materials_commonExtensionFactory.TRANSPARENCY,
+					Transparency
+				));
+			}
+
+			if (Transparent != TRANSPARENT_DEFAULT)
+			{
+				valuesObj.Add(new JProperty(
+					KHR_materials_commonExtensionFactory.TRANSPARENT,
+					Transparent
+				));
+			}
+
+			if (DoubleSided != DOUBLESIDED_DEFAULT)
+			{
+				valuesObj.Add(new JProperty(
+					KHR_materials_commonExtensionFactory.DOUBLESIDED,
+					DoubleSided
+				));	
+			}
+
+			return new JProperty(KHR_materials_commonExtensionFactory.EXTENSION_NAME, ext);
+		}
+	}
+}

--- a/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtension.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtension.cs
@@ -26,13 +26,13 @@ namespace GLTF.Schema
 		/// <summary>
 		/// RGBA value for ambient light reflected from the surface of the object.
 		/// </summary>
-		public Color Ambient = Color.Black;
+		public Color Ambient = AMBIENT_DEFAULT;
 		public static readonly Color AMBIENT_DEFAULT = Color.Black;
 
 		/// <summary>
 		/// RGBA value for light emitted by the surface of the object.
 		/// </summary>
-		public Color EmissionColor = Color.Black;
+		public Color EmissionColor = EMISSIONCOLOR_DEFAULT;
 		public static readonly Color EMISSIONCOLOR_DEFAULT = Color.Black;
 
 		/// <summary>
@@ -44,7 +44,7 @@ namespace GLTF.Schema
 		/// <summary>
 		/// RGBA value defining the amount of light diffusely reflected from the surface of the object.
 		/// </summary>
-		public Color DiffuseColor = Color.Black;
+		public Color DiffuseColor = DIFFUSECOLOR_DEFAULT;
 		public static readonly Color DIFFUSECOLOR_DEFAULT = Color.Black;
 
 		/// <summary>
@@ -56,7 +56,7 @@ namespace GLTF.Schema
 		/// <summary>
 		/// RGBA value defining the color of light specularly reflected from the surface of the object.
 		/// </summary>
-		public Color SpecularColor = Color.Black;
+		public Color SpecularColor = SPECULARCOLOR_DEFAULT;
 		public static readonly Color SPECULARCOLOR_DEFAULT = Color.Black;
 
 		/// <summary>
@@ -68,13 +68,13 @@ namespace GLTF.Schema
 		/// <summary>
 		/// Defines the specularity or roughness of the specular reflection lobe of the object.
 		/// </summary>
-		public float Shininess = 0.0f;
+		public float Shininess = SHININESS_DEFAULT;
 		public static readonly float SHININESS_DEFAULT = 0.0f;
 
 		/// <summary>
 		/// Declares the amount of transparency as an opacity value between 0.0 and 1.0.
 		/// </summary>
-		public float Transparency = 1.0f;
+		public float Transparency = TRANSPARENCY_DEFAULT;
 		public static readonly float TRANSPARENCY_DEFAULT = 1.0f;
 
 		/// <summary>
@@ -82,13 +82,13 @@ namespace GLTF.Schema
 		/// Corresponds to enabling the BLEND render state, setting the depthMask property to false,
 		/// and defining blend equations and blend functions as described in the implementation note.
 		/// </summary>
-		public bool Transparent = false;
+		public bool Transparent = TRANSPARENT_DEFAULT;
 		public static readonly bool TRANSPARENT_DEFAULT = false;
 
 		/// <summary>
 		/// Declares whether backface culling should be disabled for this visual. Corresponds to disabling the CULL_FACE render state.
 		/// </summary>
-		public bool DoubleSided = false;
+		public bool DoubleSided = DOUBLESIDED_DEFAULT;
 		public static readonly bool DOUBLESIDED_DEFAULT = false;
 
 

--- a/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtension.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtension.cs
@@ -38,7 +38,7 @@ namespace GLTF.Schema
 		/// <summary>
 		/// Texture for light emitted by the surface of the object.
 		/// </summary>
-		public TextureInfo EmissionTexture;
+		public TextureInfo EmissionTexture = EMISSIONTEXTURE_DEFAULT;
 		public static readonly TextureInfo EMISSIONTEXTURE_DEFAULT = new TextureInfo();
 
 		/// <summary>
@@ -50,7 +50,7 @@ namespace GLTF.Schema
 		/// <summary>
 		/// Texture defining the amount of light diffusely reflected from the surface of the object.
 		/// </summary>
-		public TextureInfo DiffuseTexture;
+		public TextureInfo DiffuseTexture = DIFFUSETEXTURE_DEFAULT;
 		public static readonly TextureInfo DIFFUSETEXTURE_DEFAULT = new TextureInfo();
 
 		/// <summary>
@@ -62,7 +62,7 @@ namespace GLTF.Schema
 		/// <summary>
 		/// Texture defining the color of light specularly reflected from the surface of the object.
 		/// </summary>
-		public TextureInfo SpecularTexture;
+		public TextureInfo SpecularTexture = SPECULARTEXTURE_DEFAULT;
 		public static readonly TextureInfo SPECULARTEXTURE_DEFAULT = new TextureInfo();
 
 		/// <summary>
@@ -169,7 +169,7 @@ namespace GLTF.Schema
 				));
 			}
 
-			if (EmissionTexture != null)
+			if (EmissionTexture != EMISSIONTEXTURE_DEFAULT)
 			{
 				valuesObj.Add(new JProperty(
 					KHR_materials_commonExtensionFactory.EMISSION,
@@ -195,7 +195,7 @@ namespace GLTF.Schema
 				Technique == CommonTechnique.BLINN ||
 				Technique == CommonTechnique.CONSTANT)
 			{
-				if (DiffuseTexture != null)
+				if (DiffuseTexture != DIFFUSETEXTURE_DEFAULT)
 				{
 					valuesObj.Add(new JProperty(
 						KHR_materials_commonExtensionFactory.DIFFUSE,
@@ -220,7 +220,7 @@ namespace GLTF.Schema
 			if (Technique == CommonTechnique.PHONG ||
 				Technique == CommonTechnique.BLINN)
 			{
-				if (SpecularTexture != null)
+				if (SpecularTexture != SPECULARTEXTURE_DEFAULT)
 				{
 					valuesObj.Add(new JProperty(
 						KHR_materials_commonExtensionFactory.SPECULAR,

--- a/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtensionFactory.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtensionFactory.cs
@@ -1,0 +1,155 @@
+﻿using Newtonsoft.Json.Linq;
+using GLTF.Extensions;
+using GLTF.Math;
+using System;
+
+namespace GLTF.Schema
+{
+	public class KHR_materials_commonExtensionFactory : ExtensionFactory
+	{
+		public const string EXTENSION_NAME = "KHR_materials_common";
+
+		public const string TECHNIQUE = "technique";
+		public const string VALUES = "values";
+		public const string AMBIENT = "ambient";
+		public const string EMISSION = "emission";
+		public const string DIFFUSE = "diffuse";
+		public const string SPECULAR = "specular";
+		public const string SHININESS = "shininess";
+		public const string TRANSPARENCY = "transparency";
+		public const string TRANSPARENT = "transparent";
+		public const string DOUBLESIDED = "doublesided";
+
+
+		public KHR_materials_commonExtensionFactory()
+		{
+			ExtensionName = EXTENSION_NAME;
+		}
+
+		public override IExtension Deserialize(GLTFRoot root, JProperty extensionToken)
+		{
+			KHR_materials_commonExtension.CommonTechnique technique = KHR_materials_commonExtension.TECHNIQUE_DEFAULT;
+			Color ambient = KHR_materials_commonExtension.AMBIENT_DEFAULT;
+			Color emissionColor = KHR_materials_commonExtension.EMISSIONCOLOR_DEFAULT;
+			TextureInfo emissionTexture = new TextureInfo();
+			Color diffuseColor = KHR_materials_commonExtension.DIFFUSECOLOR_DEFAULT;
+			TextureInfo diffuseTexture = new TextureInfo();
+			Color specularColor = KHR_materials_commonExtension.SPECULARCOLOR_DEFAULT;
+			TextureInfo specularTexture = new TextureInfo();
+			float shininess = KHR_materials_commonExtension.SHININESS_DEFAULT;
+			float transparency = KHR_materials_commonExtension.TRANSPARENCY_DEFAULT;
+			bool transparent = KHR_materials_commonExtension.TRANSPARENT_DEFAULT;
+			bool doubleSided = KHR_materials_commonExtension.DOUBLESIDED_DEFAULT;
+
+			if (extensionToken != null)
+			{
+				JToken techniqueToken = extensionToken.Value[TECHNIQUE];
+				if(techniqueToken != null)
+				{
+					switch(techniqueToken.DeserializeAsString())
+					{
+						case "CONSTANT":
+							technique = KHR_materials_commonExtension.CommonTechnique.CONSTANT;
+							break;
+						case "LAMBERT":
+							technique = KHR_materials_commonExtension.CommonTechnique.LAMBERT;
+							break;
+						case "PHONG":
+							technique = KHR_materials_commonExtension.CommonTechnique.PHONG;
+							break;
+						case "BLINN":
+							technique = KHR_materials_commonExtension.CommonTechnique.BLINN;
+							break;
+						default:
+							throw new Exception("Invalid technique type: " + techniqueToken.DeserializeAsString());
+					}
+				}
+
+				JToken valuesToken = extensionToken.Value[VALUES];
+				if(valuesToken != null)
+				{
+					JObject valuesObject = valuesToken as JObject;
+					if (valuesObject != null)
+					{
+						JToken ambientToken = valuesObject[AMBIENT];
+						ambient = ambientToken != null ? ambientToken.DeserializeAsColor() : ambient;
+
+						JToken emissionToken = valuesObject[EMISSION];
+						if (emissionToken != null)
+						{
+							if (emissionToken.Type == JTokenType.Integer)
+							{
+								emissionTexture = emissionToken.DeserializeAsTexture(root);
+							}
+							else if(emissionToken.Type == JTokenType.Array)
+							{
+								emissionColor = emissionToken.DeserializeAsColor();
+							}
+						}
+
+						if (technique == KHR_materials_commonExtension.CommonTechnique.LAMBERT ||
+							technique == KHR_materials_commonExtension.CommonTechnique.PHONG ||
+							technique == KHR_materials_commonExtension.CommonTechnique.BLINN ||
+							technique == KHR_materials_commonExtension.CommonTechnique.CONSTANT)
+						{
+							JToken diffuseToken = valuesObject[DIFFUSE];
+							if (diffuseToken != null)
+							{
+								if (diffuseToken.Type == JTokenType.Integer)
+								{
+									diffuseTexture = diffuseToken.DeserializeAsTexture(root);
+								}
+								else if (diffuseToken.Type == JTokenType.Array)
+								{
+									diffuseColor = diffuseToken.DeserializeAsColor();
+								}
+							}
+						}
+
+						if (technique == KHR_materials_commonExtension.CommonTechnique.PHONG ||
+							technique == KHR_materials_commonExtension.CommonTechnique.BLINN)
+						{
+							JToken specularToken = valuesObject[SPECULAR];
+							if (specularToken == null)
+							{
+								if (specularToken.Type == JTokenType.Integer)
+								{
+									diffuseTexture = specularToken.DeserializeAsTexture(root);
+								}
+								else if (specularToken.Type == JTokenType.Array)
+								{
+									diffuseColor = specularToken.DeserializeAsColor();
+								}
+							}
+						}
+
+						JToken shininessToken = valuesObject[SHININESS];
+						shininess = shininessToken != null ? shininessToken.DeserializeAsFloat() : shininess;
+
+						JToken transparencyToken = valuesObject[TRANSPARENCY];
+						transparency = transparencyToken != null ? transparencyToken.DeserializeAsFloat() : transparency;
+
+						JToken transparentToken = valuesObject[TRANSPARENT];
+						transparent = transparentToken != null ? transparentToken.DeserializeAsBool() : transparent;
+
+						JToken doubleSidedToken = valuesObject[DOUBLESIDED];
+						doubleSided = doubleSidedToken != null ? doubleSidedToken.DeserializeAsBool() : doubleSided;
+					}
+				}
+			}
+			
+			return new KHR_materials_commonExtension(technique,
+				ambient,
+				emissionColor,
+				emissionTexture,
+				diffuseColor,
+				diffuseTexture,
+				specularColor,
+				specularTexture,
+				shininess,
+				transparency,
+				transparent,
+				doubleSided);
+		}
+	}
+}

--- a/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtensionFactory.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/KHR_materials_commonExtensionFactory.cs
@@ -110,7 +110,7 @@ namespace GLTF.Schema
 							technique == KHR_materials_commonExtension.CommonTechnique.BLINN)
 						{
 							JToken specularToken = valuesObject[SPECULAR];
-							if (specularToken == null)
+							if (specularToken != null)
 							{
 								if (specularToken.Type == JTokenType.Integer)
 								{

--- a/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
+++ b/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
@@ -649,14 +649,6 @@ namespace GLTF
 						}
 					}
 
-					MaterialCommonConstant commonConstant = material.CommonConstant;
-					if (commonConstant?.LightmapTexture != null)
-					{
-						TextureId textureId = material.CommonConstant.LightmapTexture.Index;
-						textureId.Id += previousGLTFSizes.PreviousTextureCount;
-						textureId.Root = mergeToRoot;
-					}
-
 					if (material.EmissiveTexture != null)
 					{
 						TextureId textureId = material.EmissiveTexture.Index;

--- a/GLTFSerialization/GLTFSerialization/Schema/GLTFMaterial.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/GLTFMaterial.cs
@@ -16,11 +16,6 @@ namespace GLTF.Schema
 		public PbrMetallicRoughness PbrMetallicRoughness;
 
 		/// <summary>
-		/// A set of parameter values used to light flat-shaded materials
-		/// </summary>
-		public MaterialCommonConstant CommonConstant;
-
-		/// <summary>
 		/// A tangent space normal map. Each texel represents the XYZ components of a
 		/// normal vector in tangent space.
 		/// </summary>
@@ -92,11 +87,6 @@ namespace GLTF.Schema
 				PbrMetallicRoughness = new PbrMetallicRoughness(material.PbrMetallicRoughness, gltfRoot);
 			}
 
-			if (material.CommonConstant != null)
-			{
-				CommonConstant = new MaterialCommonConstant(material.CommonConstant, gltfRoot);
-			}
-
 			if (material.NormalTexture != null)
 			{
 				NormalTexture = new NormalTextureInfo(material.NormalTexture, gltfRoot);
@@ -130,9 +120,6 @@ namespace GLTF.Schema
 				{
 					case "pbrMetallicRoughness":
 						material.PbrMetallicRoughness = PbrMetallicRoughness.Deserialize(root, reader);
-						break;
-					case "commonConstant":
-						material.CommonConstant = MaterialCommonConstant.Deserialize(root, reader);
 						break;
 					case "normalTexture":
 						material.NormalTexture = NormalTextureInfo.Deserialize(root, reader);
@@ -172,12 +159,6 @@ namespace GLTF.Schema
 			{
 				writer.WritePropertyName("pbrMetallicRoughness");
 				PbrMetallicRoughness.Serialize(writer);
-			}
-
-			if (CommonConstant != null)
-			{
-				writer.WritePropertyName("commonConstant");
-				CommonConstant.Serialize(writer);
 			}
 
 			if (NormalTexture != null)

--- a/GLTFSerialization/GLTFSerialization/Schema/GLTFProperty.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/GLTFProperty.cs
@@ -10,9 +10,10 @@ namespace GLTF.Schema
 	{
 		private static Dictionary<string, ExtensionFactory> _extensionRegistry = new Dictionary<string, ExtensionFactory>()
 		{
+			{ FB_materials_modmapExtensionFactory.EXTENSION_NAME, new FB_materials_modmapExtensionFactory() },
 			{ ExtTextureTransformExtensionFactory.EXTENSION_NAME, new ExtTextureTransformExtensionFactory() },
 			{ KHR_materials_pbrSpecularGlossinessExtensionFactory.EXTENSION_NAME, new KHR_materials_pbrSpecularGlossinessExtensionFactory() },
-      { MSFT_LODExtensionFactory.EXTENSION_NAME, new MSFT_LODExtensionFactory() }
+			{ MSFT_LODExtensionFactory.EXTENSION_NAME, new MSFT_LODExtensionFactory() }
 		};
 		private static DefaultExtensionFactory _defaultExtensionFactory = new DefaultExtensionFactory();
 

--- a/GLTFSerialization/GLTFSerialization/Schema/GLTFProperty.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/GLTFProperty.cs
@@ -11,6 +11,7 @@ namespace GLTF.Schema
 		private static Dictionary<string, ExtensionFactory> _extensionRegistry = new Dictionary<string, ExtensionFactory>()
 		{
 			{ FB_materials_modmapExtensionFactory.EXTENSION_NAME, new FB_materials_modmapExtensionFactory() },
+			{ KHR_materials_commonExtensionFactory.EXTENSION_NAME, new KHR_materials_commonExtensionFactory() },
 			{ ExtTextureTransformExtensionFactory.EXTENSION_NAME, new ExtTextureTransformExtensionFactory() },
 			{ KHR_materials_pbrSpecularGlossinessExtensionFactory.EXTENSION_NAME, new KHR_materials_pbrSpecularGlossinessExtensionFactory() },
 			{ MSFT_LODExtensionFactory.EXTENSION_NAME, new MSFT_LODExtensionFactory() }

--- a/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFExportMenu.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Editor/Scripts/GLTFExportMenu.cs
@@ -28,7 +28,7 @@ public class GLTFExportMenu : EditorWindow
         EditorGUILayout.LabelField("Importer", EditorStyles.boldLabel);
         EditorGUILayout.Separator();
         EditorGUILayout.HelpBox("UnityGLTF version 0.1", MessageType.Info);
-        EditorGUILayout.HelpBox("Supported extensions: KHR_material_pbrSpecularGlossiness, ExtTextureTransform", MessageType.Info);
+        EditorGUILayout.HelpBox("Supported extensions: KHR_material_pbrSpecularGlossiness, KHR_texture_transform, FB_materials_modmap", MessageType.Info);
     }
 
     [MenuItem("GLTF/Export Selected")]

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -1196,7 +1196,7 @@ namespace UnityGLTF
 			return pbr;
 		}
 
-		private void ExportCommonMaterial(GLTFMaterial material, Material materialObj)
+		private bool ExportCommonMaterial(GLTFMaterial material, Material materialObj)
 		{
 			if (_root.ExtensionsUsed == null)
 			{

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -924,10 +924,6 @@ namespace UnityGLTF
 			{
 				material.PbrMetallicRoughness = ExportPBRMetallicRoughness(materialObj);
 			}
-			else if (IsCommonConstant(materialObj))
-			{
-				material.CommonConstant = ExportCommonConstant(materialObj);
-			}
 
 			if(HasMaterialsModmap(materialObj, renderer))
 			{
@@ -999,13 +995,6 @@ namespace UnityGLTF
 		private bool IsPBRMetallicRoughness(Material material)
 		{
 			return material.HasProperty("_Metallic") && material.HasProperty("_MetallicGlossMap");
-		}
-
-		private bool IsCommonConstant(Material material)
-		{
-			return material.HasProperty("_AmbientFactor") &&
-			material.HasProperty("_LightMap") &&
-			material.HasProperty("_LightFactor");
 		}
 
 		private bool HasMaterialsModmap(Material material, MeshRenderer renderer)
@@ -1168,57 +1157,6 @@ namespace UnityGLTF
 			}
 
 			return pbr;
-		}
-
-		private MaterialCommonConstant ExportCommonConstant(Material materialObj)
-		{
-			if (_root.ExtensionsUsed == null)
-			{
-				_root.ExtensionsUsed = new List<string>(new[] { "KHR_materials_common" });
-			}
-			else if (!_root.ExtensionsUsed.Contains("KHR_materials_common"))
-			{
-				_root.ExtensionsUsed.Add("KHR_materials_common");
-			}
-
-			if (RequireExtensions)
-			{
-				if (_root.ExtensionsRequired == null)
-				{
-					_root.ExtensionsRequired = new List<string>(new[] { "KHR_materials_common" });
-				}
-				else if (!_root.ExtensionsRequired.Contains("KHR_materials_common"))
-				{
-					_root.ExtensionsRequired.Add("KHR_materials_common");
-				}
-			}
-
-			var constant = new MaterialCommonConstant();
-
-			if (materialObj.HasProperty("_AmbientFactor"))
-			{
-				constant.AmbientFactor = materialObj.GetColor("_AmbientFactor").ToNumericsColorRaw();
-			}
-
-			if (materialObj.HasProperty("_LightMap"))
-			{
-				var lmTex = materialObj.GetTexture("_LightMap");
-
-				if (lmTex != null)
-				{
-					constant.LightmapTexture = ExportTextureInfo(lmTex, TextureMapType.Light);
-					Vector2 offset = materialObj.GetTextureOffset("_LightMap");
-					Vector2 scale = materialObj.GetTextureScale("_LightMap");
-					ExportTextureTransform(constant.LightmapTexture, scale, offset);
-				}
-			}
-
-			if (materialObj.HasProperty("_LightFactor"))
-			{
-				constant.LightmapFactor = materialObj.GetColor("_LightFactor").ToNumericsColorRaw();
-			}
-
-			return constant;
 		}
 
 		private void ExportModmap(GLTFMaterial material, Material materialObj, MeshRenderer renderer)

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -78,7 +78,6 @@ namespace UnityGLTF
 		}
 		private readonly Dictionary<PrimKey, MeshId> _primOwner = new Dictionary<PrimKey, MeshId>();
 		private readonly Dictionary<Mesh, MeshPrimitive[]> _meshToPrims = new Dictionary<Mesh, MeshPrimitive[]>();
-		private readonly Dictionary<int, TextureId> _existedLightmap = new Dictionary<int, TextureId>();
 
 		// Settings
 		public static bool ExportNames = true;
@@ -1004,36 +1003,32 @@ namespace UnityGLTF
 		private bool IsCommonConstantMaterial(Material material)
 		{
 			return material.HasProperty("_Ambient") &&
-				(material.HasProperty("_EmissionTex") || material.HasProperty("_EmissionColor")) &&
-				material.HasProperty("_Transparency");
+				(material.HasProperty("_EmissionTex") || material.HasProperty("_EmissionColor"));
 		}
 
 		private bool IsCommonLambertMaterial(Material material)
 		{
-			return material.HasProperty("_Color") && material.HasProperty("_Ambient") &&
+			return material.HasProperty("_Ambient") &&
 				(material.HasProperty("_MainTex") || material.HasProperty("_DiffuseColor")) &&
-				(material.HasProperty("_EmissionTex") || material.HasProperty("_EmissionColor")) &&
-				material.HasProperty("_Transparency");
+				(material.HasProperty("_EmissionTex") || material.HasProperty("_EmissionColor"));
 		}
 
 		private bool IsCommonPhongMaterial(Material material)
 		{
-			return material.HasProperty("_Color") && material.HasProperty("_Ambient") &&
+			return material.HasProperty("_Ambient") &&
 				(material.HasProperty("_MainTex") || material.HasProperty("_DiffuseColor")) &&
 				(material.HasProperty("_EmissionTex") || material.HasProperty("_EmissionColor")) &&
 				(material.HasProperty("_SpecularTex") || material.HasProperty("_SpecularColor")) &&
-				material.HasProperty("_Shininess") &&
-				material.HasProperty("_Transparency");
+				material.HasProperty("_Shininess");
 		}
 
 		private bool IsCommonBlinnMaterial(Material material)
 		{
-			return material.HasProperty("_Color") && material.HasProperty("_Ambient") &&
+			return material.HasProperty("_Ambient") &&
 				(material.HasProperty("_MainTex") || material.HasProperty("_DiffuseColor")) &&
 				(material.HasProperty("_EmissionTex") || material.HasProperty("_EmissionColor")) &&
 				(material.HasProperty("_SpecularTex") || material.HasProperty("_SpecularColor")) &&
-				material.HasProperty("_Shininess") &&
-				material.HasProperty("_Transparency");
+				material.HasProperty("_Shininess");
 		}
 
 		private bool HasMaterialsModmap(Material material, MeshRenderer renderer)
@@ -1406,7 +1401,7 @@ namespace UnityGLTF
 
 				if (lmTex != null)
 				{
-					modmapTexture = ExportLightmapTextureInfo(lmTex, TextureMapType.Light);
+					modmapTexture = ExportTextureInfo(lmTex, TextureMapType.Light);
 					Vector2 offset = materialObj.GetTextureOffset("_LightMap");
 					Vector2 scale = materialObj.GetTextureScale("_LightMap");
 					ExportTextureTransform(modmapTexture, scale, offset);
@@ -1423,7 +1418,7 @@ namespace UnityGLTF
 					lmTex = lightmapData.lightmapColor;
 					if (lmTex != null)
 					{
-						modmapTexture = ExportLightmapTextureInfo(lmTex, TextureMapType.Light);
+						modmapTexture = ExportTextureInfo(lmTex, TextureMapType.Light);
 						var lmScaleOffset = renderer.lightmapScaleOffset;
 						ExportTextureTransform(modmapTexture, new Vector2(lmScaleOffset.x, lmScaleOffset.y), new Vector2(lmScaleOffset.z, lmScaleOffset.w));
 					}
@@ -1434,17 +1429,6 @@ namespace UnityGLTF
 				modmapFactor,
 				modmapTexture
 			);
-		}
-
-		private TextureInfo ExportLightmapTextureInfo(Texture texture, TextureMapType textureMapType)
-		{
-			var info = new TextureInfo();
-			if (!_existedLightmap.TryGetValue(texture.GetInstanceID(), out info.Index))
-			{
-				info = ExportTextureInfo(texture, textureMapType);
-				_existedLightmap.Add(texture.GetInstanceID(), info.Index);
-			}
-			return info;
 		}
 
 		private TextureInfo ExportTextureInfo(Texture texture, TextureMapType textureMapType)

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -925,7 +925,10 @@ namespace UnityGLTF
 			}
 			else
 			{
-				ExportCommonMaterial(material, materialObj);
+				if (!ExportCommonMaterial(material, materialObj)) 
+				{
+					throw new Exception(String.Format("Please check the material of game object {0} and change a valid one.", renderer.transform.name));
+				}
 			}
 
 			if(HasMaterialsModmap(materialObj, renderer))
@@ -1338,7 +1341,10 @@ namespace UnityGLTF
 				technique = KHR_materials_commonExtension.CommonTechnique.CONSTANT;
 			}
 
-			if(technique == KHR_materials_commonExtension.CommonTechnique.NONE) throw new Exception("Please check the material and change a valid one.");
+			if (technique == KHR_materials_commonExtension.CommonTechnique.NONE)
+			{
+				return false;
+			}
 
 			material.Extensions[KHR_materials_commonExtensionFactory.EXTENSION_NAME] = new KHR_materials_commonExtension(
 				technique,
@@ -1354,6 +1360,8 @@ namespace UnityGLTF
 				transparent,
 				doubleSided
 			);
+
+			return true;
 		}
 
 		private void ExportModmap(GLTFMaterial material, Material materialObj, MeshRenderer renderer)

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -1196,7 +1196,6 @@ namespace UnityGLTF
 				modmapFactor = new GLTF.Math.Vector3(color.r, color.g, color.b);
 			}
 
-			TextureInfo lightmapTexture = null;
 			Texture lmTex = null;
 
 			if (materialObj.HasProperty("_LightMap"))
@@ -1205,10 +1204,10 @@ namespace UnityGLTF
 
 				if (lmTex != null)
 				{
-					lightmapTexture = ExportLightmapTextureInfo(lmTex, TextureMapType.Light);
+					modmapTexture = ExportLightmapTextureInfo(lmTex, TextureMapType.Light);
 					Vector2 offset = materialObj.GetTextureOffset("_LightMap");
 					Vector2 scale = materialObj.GetTextureScale("_LightMap");
-					ExportTextureTransform(lightmapTexture, scale, offset);
+					ExportTextureTransform(modmapTexture, scale, offset);
 				}
 			}
 
@@ -1222,9 +1221,9 @@ namespace UnityGLTF
 					lmTex = lightmapData.lightmapColor;
 					if (lmTex != null)
 					{
-						lightmapTexture = ExportLightmapTextureInfo(lmTex, TextureMapType.Light);
+						modmapTexture = ExportLightmapTextureInfo(lmTex, TextureMapType.Light);
 						var lmScaleOffset = renderer.lightmapScaleOffset;
-						ExportTextureTransform(lightmapTexture, new Vector2(lmScaleOffset.x, lmScaleOffset.y), new Vector2(lmScaleOffset.z, lmScaleOffset.w));
+						ExportTextureTransform(modmapTexture, new Vector2(lmScaleOffset.x, lmScaleOffset.y), new Vector2(lmScaleOffset.z, lmScaleOffset.w));
 					}
 				}
 			}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
@@ -1762,16 +1762,6 @@ namespace UnityGLTF
 				}
 			}
 
-			if (def.CommonConstant != null)
-			{
-				if (def.CommonConstant.LightmapTexture != null)
-				{
-					var textureId = def.CommonConstant.LightmapTexture.Index;
-
-					tasks.Add(ConstructImageBuffer(textureId.Value, textureId.Id));
-				}
-			}
-
 			if (def.NormalTexture != null)
 			{
 				var textureId = def.NormalTexture.Index;
@@ -1810,6 +1800,18 @@ namespace UnityGLTF
 				if (specGlossDef.SpecularGlossinessTexture != null)
 				{
 					var textureId = specGlossDef.SpecularGlossinessTexture.Index;
+					tasks.Add(ConstructImageBuffer(textureId.Value, textureId.Id));
+				}
+			}
+
+			// FB_materials_modmap extension
+			const string modmapExtName = FB_materials_modmapExtensionFactory.EXTENSION_NAME;
+			if (def.Extensions != null && def.Extensions.ContainsKey(modmapExtName))
+			{
+				var modmapDef = (FB_materials_modmapExtension)def.Extensions[modmapExtName];
+				if (modmapDef.ModmapTexture != null)
+				{
+					var textureId = modmapDef.ModmapTexture.Index;
 					tasks.Add(ConstructImageBuffer(textureId.Value, textureId.Id));
 				}
 			}
@@ -2088,7 +2090,6 @@ namespace UnityGLTF
 				_defaultLoadedMaterial = materialWrapper;
 			}
 		}
-
 
 		protected virtual int GetTextureSourceId(GLTFTexture texture)
 		{

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonConstant.shader
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonConstant.shader
@@ -1,0 +1,52 @@
+﻿Shader "GLTF/Constant"
+{
+    Properties
+    {
+        _Color ("Color", Color) = (1,1,1,1)
+		_EmissionColor("Emission", Color) = (0,0,0,1)
+		_Ambient ("Ambient", Color) = (0,0,0,1)
+		_MainTex("Albedo (RGB)", 2D) = "white" {}
+		_LightColor ("Light Color", Color) = (1,1,1,1)
+    }
+
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 200
+
+        CGPROGRAM
+
+        // Use shader model 3.0 target, to get nicer looking lighting
+        #pragma target 3.0
+		#pragma surface surf GLTFConstant
+
+        sampler2D _MainTex;
+
+        struct Input
+        {
+            float2 uv_MainTex;
+        };
+
+		fixed4 _Color;
+		fixed4 _EmissionColor;
+		fixed4 _Ambient;
+		fixed4 _LightColor;
+
+		half4 LightingGLTFConstant(SurfaceOutput s, half3 lightDir, half3 viewDir, half atten) {
+			half4 c;
+			c.rgb = (_EmissionColor.rgb + _Ambient.rgb * _LightColor.rgb +  s.Albedo) * atten;
+			c.a = s.Alpha;
+			return c;
+		}
+
+        void surf (Input IN, inout SurfaceOutput o)
+        {
+            // Albedo comes from a texture tinted by color
+            fixed4 c = tex2D (_MainTex, IN.uv_MainTex) * _Color;
+            o.Albedo = c.rgb;
+			o.Alpha = c.a;
+        }
+        ENDCG
+    }
+    FallBack "Diffuse"
+}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonConstant.shader.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonConstant.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 6eb990052de3ded4694ad1b6abc5f778
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonLambert.shader
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonLambert.shader
@@ -1,0 +1,53 @@
+﻿Shader "GLTF/Lambert"
+{
+    Properties
+    {
+        _Color ("Color", Color) = (1,1,1,1)
+		_Ambient ("Ambient", Color) = (0,0,0,1)
+        _MainTex ("Albedo (RGB)", 2D) = "white" {}
+		_EmissionColor ("Emission", Color) = (0,0,0,1)
+		_LightColor ("Light Color", Color) = (1,1,1,1)
+    }
+
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 200
+
+        CGPROGRAM
+
+        // Use shader model 3.0 target, to get nicer looking lighting
+        #pragma target 3.0
+		#pragma surface surf GLTFLambert
+
+        sampler2D _MainTex;
+
+        struct Input
+        {
+            float2 uv_MainTex;
+        };
+
+		fixed4 _Color;
+		fixed4 _Ambient;
+		fixed4 _EmissionColor;
+		fixed4 _LightColor;
+
+		half4 LightingGLTFLambert (SurfaceOutput s, half3 lightDir, half atten) {
+			half NdotL = dot(s.Normal, lightDir);
+			half4 c;
+			c.rgb = (_EmissionColor.rgb + _Ambient.rgb * _LightColor.rgb + s.Albedo * _LightColor.rgb * NdotL) * atten;
+			c.a = s.Alpha;
+			return c;
+		}
+
+        void surf (Input IN, inout SurfaceOutput o)
+        {
+            // Albedo comes from a texture tinted by color
+            fixed4 c = tex2D (_MainTex, IN.uv_MainTex) * _Color;
+            o.Albedo = c.rgb;
+            o.Alpha = c.a;
+        }
+        ENDCG
+    }
+    FallBack "Diffuse"
+}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonLambert.shader.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonLambert.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4ac44b4554ee03d48bcefa15243b55fa
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonPhong.shader
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonPhong.shader
@@ -1,0 +1,63 @@
+﻿Shader "GLTF/Phong"
+{
+    Properties
+    {
+        _Color ("Color", Color) = (1,1,1,1)
+		_Ambient ("Ambient", Color) = (0,0,0,1)
+        _MainTex ("Albedo (RGB)", 2D) = "white" {}
+		_EmissionColor ("Emission", Color) = (0,0,0,1)
+		_SpecularColor ("Specular", Color) = (0,0,0,1)
+		_Shininess ("Shininess", Range(0,1)) = 0.0
+		_LightColor ("Light Color", Color) = (1,1,1,1)
+    }
+
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 200
+
+        CGPROGRAM
+
+        // Use shader model 3.0 target, to get nicer looking lighting
+        #pragma target 3.0
+		#pragma surface surf GLTFPhong
+
+        sampler2D _MainTex;
+
+        struct Input
+        {
+            float2 uv_MainTex;
+        };
+
+		fixed4 _Color;
+		fixed4 _Ambient;
+		fixed4 _EmissionColor;
+		fixed4 _SpecularColor;
+		fixed _Shininess;
+		fixed4 _LightColor;
+
+		half4 LightingGLTFPhong(SurfaceOutput s, half3 lightDir, half3 viewDir, half atten) {
+			half3 h = normalize(lightDir + viewDir);
+
+			half diff = max(0, dot(s.Normal, lightDir));
+
+			float nh = max(0, dot(s.Normal, h));
+			float spec = pow(nh, _Shininess * 48.0);
+
+			half4 c;
+			c.rgb = (_EmissionColor.rgb + _Ambient.rgb * _LightColor.rgb +  s.Albedo * _LightColor.rgb * diff + _LightColor.rgb * spec) * atten;
+			c.a = s.Alpha;
+			return c;
+		}
+
+        void surf (Input IN, inout SurfaceOutput o)
+        {
+            // Albedo comes from a texture tinted by color
+            fixed4 c = tex2D (_MainTex, IN.uv_MainTex) * _Color;
+            o.Albedo = c.rgb;
+			o.Alpha = c.a;
+        }
+        ENDCG
+    }
+    FallBack "Diffuse"
+}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonPhong.shader.meta
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Shaders/CommonPhong.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a572e78147f1e3744979311eafb9cb5d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
FB_materials_modmap is implemented to support the export of lightmap.
Remove the definition of MaterialCommonConstant.
Implement the extension KHR_materials_common for a set of common materials and lights.