### PR TITLE
Don`t export primitives if the MeshRenderer or SkinnedMeshRenderer is disabled.

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -593,8 +593,10 @@ namespace UnityGLTF
 
 		private static bool ContainsValidRenderer (GameObject gameObject)
 		{
-			return (gameObject.GetComponent<MeshFilter>() != null && gameObject.GetComponent<MeshRenderer>() != null) 
-					|| (gameObject.GetComponent<SkinnedMeshRenderer>() != null);
+			var meshRender = gameObject.GetComponent<MeshRenderer>();
+			var meshFilter = gameObject.GetComponent<MeshFilter>();
+			var skinnedMeshRender = gameObject.GetComponent<SkinnedMeshRenderer>();
+			return (meshFilter != null && meshRender != null && meshRender.enabled) || (skinnedMeshRender != null && skinnedMeshRender.enabled);
 		}
 
 		private void FilterPrimitives(Transform transform, out GameObject[] primitives, out GameObject[] nonPrimitives)


### PR DESCRIPTION
Don`t export primitives if the MeshRenderer or SkinnedMeshRenderer is disabled.