### PR TITLE
Fix the duplicated GLTFLoadException (generate a TEXCOORD_4 error instead of a warning)

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Exceptions.cs
+++ b/GLTFSerialization/GLTFSerialization/Exceptions.cs
@@ -26,6 +26,9 @@ namespace GLTF
 #endif
 	}
 
+	/// <summary>
+	/// GLTFLoad exceptions occur during runtime errors through use of the GLTFSceneImporter
+	/// </summary>
 	public class GLTFLoadException : Exception
 	{
 		public GLTFLoadException() : base() { }

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Exceptions.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Exceptions.cs
@@ -28,13 +28,4 @@ namespace UnityGLTF
 		{ }
 #endif
 	}
-
-	/// <summary>
-	/// GLTFLoad exceptions occur during runtime errors through use of the GLTFSceneImporter
-	/// </summary>
-	public class GLTFLoadException : Exception
-	{
-		public GLTFLoadException() : base() { }
-		public GLTFLoadException(string message) : base(message) { }
-	}
 }


### PR DESCRIPTION
As described in issue #499 and #577.
Delete a duplicated GLTFLoadException which emit an error instead of a warning when there is TEXCOORD_4 attribute.