### PR TITLE
Dispose of image streams in AssetCache

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Cache/AssetCache.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Cache/AssetCache.cs
@@ -70,8 +70,17 @@ namespace UnityGLTF.Cache
 
 		public void Dispose()
 		{
+			if (ImageStreamCache != null)
+			{
+				foreach (var stream in ImageStreamCache)
+				{
+					stream.Dispose();
+				}
+
+				ImageStreamCache = null;
+			}
+
 			ImageCache = null;
-			ImageStreamCache = null;
 			TextureCache = null;
 			MaterialCache = null;
 			if (BufferCache != null)

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Cache/AssetCache.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/Cache/AssetCache.cs
@@ -74,7 +74,7 @@ namespace UnityGLTF.Cache
 			{
 				foreach (var stream in ImageStreamCache)
 				{
-					stream.Dispose();
+					stream?.Dispose();
 				}
 
 				ImageStreamCache = null;


### PR DESCRIPTION
We were seeing issues with sharing violation IOExceptions when trying to delete or replace image files in a temp directory we were loading from.