### PR TITLE
Fixes for sparse accessors and additional joints

### DIFF
--- a/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
+++ b/GLTFSerialization/GLTFSerialization/GLTFHelpers.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 using GLTF.Schema;
 using GLTF.Math;
+using System.Linq;
 
 namespace GLTF
 {
@@ -224,61 +224,120 @@ namespace GLTF
 		/// <summary>
 		/// Uses the accessor to parse the buffer into attributes needed to construct the mesh primitive
 		/// </summary>
-		/// <param name="attributes">A list of attributes to parse</param>
+		/// <param name="attributes">A dictionary that contains a mapping of attribute name to data needed to parse</param>
+		/// <summary>
+		/// Uses the accessor to parse the buffer into attributes needed to construct the mesh primitive
+		/// </summary>
+		/// <param name="attributes">A dictionary that contains a mapping of attribute name to data needed to parse</param>
 		public static void BuildMeshAttributes(ref Dictionary<string, AttributeAccessor> attributes)
 		{
-			List<string> unrecognizedAttributes = new List<string>();
-			foreach (var kvp in attributes)
+			if (attributes.ContainsKey(SemanticProperties.POSITION))
 			{
-				var attributeAccessor = kvp.Value;
+				var attributeAccessor = attributes[SemanticProperties.POSITION];
 				NumericArray resultArray = attributeAccessor.AccessorContent;
 				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
-				switch (kvp.Key)
-				{
-					case SemanticProperties.POSITION:
-						attributeAccessor.AccessorId.Value.AsVertexArray(ref resultArray, bufferViewCache, offset);
-						break;
-					case SemanticProperties.NORMAL:
-						attributeAccessor.AccessorId.Value.AsNormalArray(ref resultArray, bufferViewCache, offset);
-						break;
-					case SemanticProperties.TANGENT:
-						attributeAccessor.AccessorId.Value.AsTangentArray(ref resultArray, bufferViewCache, offset);
-						break;
-					case SemanticProperties.TEXCOORD_0:
-					case SemanticProperties.TEXCOORD_1:
-					case SemanticProperties.TEXCOORD_2:
-					case SemanticProperties.TEXCOORD_3:
-						attributeAccessor.AccessorId.Value.AsTexcoordArray(ref resultArray, bufferViewCache, offset);
-						break;
-					case SemanticProperties.COLOR_0:
-						attributeAccessor.AccessorId.Value.AsColorArray(ref resultArray, bufferViewCache, offset);
-						break;
-					case SemanticProperties.WEIGHTS_0:
-					case SemanticProperties.JOINTS_0:
-						attributeAccessor.AccessorId.Value.AsVector4Array(ref resultArray, bufferViewCache, offset);
-						break;
-					case SemanticProperties.INDICES:
-						attributeAccessor.AccessorId.Value.AsUIntArray(ref resultArray, bufferViewCache, offset);
-						break;
-					default:
-						unrecognizedAttributes.Add(kvp.Key);
-						continue;
-				}
-				
+				attributeAccessor.AccessorId.Value.AsVertexArray(ref resultArray, bufferViewCache, offset);
 				attributeAccessor.AccessorContent = resultArray;
 			}
-
-			foreach (var attrib in unrecognizedAttributes) { 
-				attributes.Remove(attrib);
+			if (attributes.ContainsKey(SemanticProperties.INDICES))
+			{
+				var attributeAccessor = attributes[SemanticProperties.INDICES];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsTriangles(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
 			}
-
-			// TODO This should be a warning. Unrecognized attributes (e.g. TEXCOORD_4) should not cause full exceptions.
-			if (unrecognizedAttributes.Count > 0) {
-				throw new GLTFLoadException($"Unrecognized mesh attributes [{string.Join(", ", unrecognizedAttributes.ToArray())}]");
+			if (attributes.ContainsKey(SemanticProperties.NORMAL))
+			{
+				var attributeAccessor = attributes[SemanticProperties.NORMAL];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsNormalArray(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.TexCoord[0]))
+			{
+				var attributeAccessor = attributes[SemanticProperties.TexCoord[0]];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsTexcoordArray(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.TexCoord[1]))
+			{
+				var attributeAccessor = attributes[SemanticProperties.TexCoord[1]];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsTexcoordArray(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.TexCoord[2]))
+			{
+				var attributeAccessor = attributes[SemanticProperties.TexCoord[2]];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsTexcoordArray(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.TexCoord[3]))
+			{
+				var attributeAccessor = attributes[SemanticProperties.TexCoord[3]];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsTexcoordArray(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.Color[0]))
+			{
+				var attributeAccessor = attributes[SemanticProperties.Color[0]];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsColorArray(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.TANGENT))
+			{
+				var attributeAccessor = attributes[SemanticProperties.TANGENT];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsTangentArray(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.Weight[0]))
+			{
+				var attributeAccessor = attributes[SemanticProperties.Weight[0]];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsVector4Array(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.Weight[1]))
+			{
+				var attributeAccessor = attributes[SemanticProperties.Weight[1]];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsVector4Array(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.Joint[0]))
+			{
+				var attributeAccessor = attributes[SemanticProperties.Joint[0]];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsVector4Array(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
+			}
+			if (attributes.ContainsKey(SemanticProperties.Joint[1]))
+			{
+				var attributeAccessor = attributes[SemanticProperties.Joint[1]];
+				NumericArray resultArray = attributeAccessor.AccessorContent;
+				uint offset = LoadBufferView(attributeAccessor, out byte[] bufferViewCache);
+				attributeAccessor.AccessorId.Value.AsVector4Array(ref resultArray, bufferViewCache, offset);
+				attributeAccessor.AccessorContent = resultArray;
 			}
 		}
 
-		public static void BuildTargetAttributes (ref Dictionary<string, AttributeAccessor> attributes)
+		public static void BuildTargetAttributes(ref Dictionary<string, AttributeAccessor> attributes)
 		{
 			foreach (var kvp in attributes)
 			{

--- a/GLTFSerialization/GLTFSerialization/Schema/AccessorSparse.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/AccessorSparse.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System;
 
 namespace GLTF.Schema
 {
@@ -39,6 +40,11 @@ namespace GLTF.Schema
 		public static AccessorSparse Deserialize(GLTFRoot root, JsonReader reader)
 		{
 			var accessorSparse = new AccessorSparse();
+
+			if (reader.Read() && reader.TokenType != JsonToken.StartObject)
+			{
+				throw new Exception("Asset must be an object.");
+			}
 
 			while (reader.Read() && reader.TokenType == JsonToken.PropertyName)
 			{

--- a/GLTFSerialization/GLTFSerialization/Schema/AccessorSparseIndices.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/AccessorSparseIndices.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System;
 
 namespace GLTF.Schema
 {
@@ -40,6 +41,11 @@ namespace GLTF.Schema
 		public static AccessorSparseIndices Deserialize(GLTFRoot root, JsonReader reader)
 		{
 			var indices = new AccessorSparseIndices();
+
+			if (reader.Read() && reader.TokenType != JsonToken.StartObject)
+			{
+				throw new Exception("Asset must be an object.");
+			}
 
 			while (reader.Read() && reader.TokenType == JsonToken.PropertyName)
 			{

--- a/GLTFSerialization/GLTFSerialization/Schema/AccessorSparseValues.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/AccessorSparseValues.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System;
 
 namespace GLTF.Schema
 {
@@ -31,6 +32,11 @@ namespace GLTF.Schema
 		public static AccessorSparseValues Deserialize(GLTFRoot root, JsonReader reader)
 		{
 			var values = new AccessorSparseValues();
+
+			if (reader.Read() && reader.TokenType != JsonToken.StartObject)
+			{
+				throw new Exception("Asset must be an object.");
+			}
 
 			while (reader.Read() && reader.TokenType == JsonToken.PropertyName)
 			{

--- a/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
@@ -336,10 +336,12 @@ namespace GLTF.Schema
 		public static readonly string[] Color = { COLOR_0 };
 
 		public const string WEIGHTS_0 = "WEIGHTS_0";
-		public static readonly string[] Weight = { WEIGHTS_0 };
+		public const string WEIGHTS_1 = "WEIGHTS_1";
+		public static readonly string[] Weight = { WEIGHTS_0, WEIGHTS_1 };
 
 		public const string JOINTS_0 = "JOINTS_0";
-		public static readonly string[] Joint = { JOINTS_0 };
+		public const string JOINTS_1 = "JOINTS_1";
+		public static readonly string[] Joint = { JOINTS_0, JOINTS_1 };
 
 		/// <summary>
 		/// Parse out the index of a given semantic property.

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
@@ -794,10 +794,24 @@ namespace UnityGLTF
 				var target = primitive.Targets[i];
 				newTargets.Add(new Dictionary<string, AttributeAccessor>());
 
+				NumericArray[] sparseNORMALS = null;//NORMALS
+				NumericArray[] sparsePOSITIONS = null;//POSITIONS
+				NumericArray[] sparseTANGENTS = null;//TANGENTS
+
 				//NORMALS, POSITIONS, TANGENTS
 				foreach (var targetAttribute in target)
 				{
-					BufferId bufferIdPair = targetAttribute.Value.Value.BufferView.Value.Buffer;
+
+					BufferId bufferIdPair = null;
+					if (targetAttribute.Value.Value.Sparse == null)
+					{
+						bufferIdPair = targetAttribute.Value.Value.BufferView.Value.Buffer;
+					}
+					else
+					{
+						bufferIdPair = primitive.Attributes[targetAttribute.Key].Value.BufferView.Value.Buffer;
+						targetAttribute.Value.Value.BufferView = primitive.Attributes[targetAttribute.Key].Value.BufferView;
+					}
 					GLTFBuffer buffer = bufferIdPair.Value;
 					int bufferID = bufferIdPair.Id;
 
@@ -812,13 +826,235 @@ namespace UnityGLTF
 						Stream = _assetCache.BufferCache[bufferID].Stream,
 						Offset = (uint)_assetCache.BufferCache[bufferID].ChunkOffset
 					};
+					if (targetAttribute.Value.Value.Sparse != null)
+					{
+						//Values
+						var bufferId = targetAttribute.Value.Value.Sparse.Values.BufferView.Value.Buffer;
+						var bufferData = await GetBufferData(bufferId);
+						AttributeAccessor SparseValues = new AttributeAccessor
+						{
+							AccessorId = targetAttribute.Value,
+							Stream = bufferData.Stream,
+							Offset = (uint)bufferData.ChunkOffset
+						};
+						uint offset1 = LoadBufferView(SparseValues.AccessorId.Value.Sparse.Values.BufferView.Value, SparseValues.Offset, SparseValues.Stream, out byte[] bufferViewCache1);
 
+
+						//Indices
+						bufferId = targetAttribute.Value.Value.Sparse.Indices.BufferView.Value.Buffer;
+						bufferData = await GetBufferData(bufferId);
+						AttributeAccessor SparseIndices = new AttributeAccessor
+						{
+							AccessorId = targetAttribute.Value,
+							Stream = bufferData.Stream,
+							Offset = (uint)bufferData.ChunkOffset
+						};
+						uint offset2 = LoadBufferView(SparseIndices.AccessorId.Value.Sparse.Indices.BufferView.Value, SparseIndices.Offset, SparseIndices.Stream, out byte[] bufferViewCache2);
+
+
+
+
+						if (targetAttribute.Key.Equals("NORMAL"))
+						{
+							sparseNORMALS = new NumericArray[2];
+							AsSparseVector3Array(targetAttribute.Value.Value, ref sparseNORMALS[0], bufferViewCache1, offset1);
+							AsSparseUIntArray(targetAttribute.Value.Value, ref sparseNORMALS[1], bufferViewCache2, offset2);
+						}
+						else if (targetAttribute.Key.Equals("POSITION"))
+						{
+							sparsePOSITIONS = new NumericArray[2];
+							AsSparseVector3Array(targetAttribute.Value.Value, ref sparsePOSITIONS[0], bufferViewCache1, offset1);
+							AsSparseUIntArray(targetAttribute.Value.Value, ref sparsePOSITIONS[1], bufferViewCache2, offset2);
+						}
+						else if (targetAttribute.Key.Equals("TANGENT"))
+						{
+							sparseTANGENTS = new NumericArray[2];
+							AsSparseVector3Array(targetAttribute.Value.Value, ref sparseTANGENTS[0], bufferViewCache1, offset1);
+							AsSparseUIntArray(targetAttribute.Value.Value, ref sparseTANGENTS[1], bufferViewCache2, offset2);
+						}
+					}
 				}
 
 				var att = newTargets[i];
 				GLTFHelpers.BuildTargetAttributes(ref att);
+
+				if (sparseNORMALS != null)
+				{
+					NumericArray before = new NumericArray();
+					before.AsVec3s = new GLTF.Math.Vector3[att["NORMAL"].AccessorContent.AsVec3s.Length];
+					for (int j = 0; j < sparseNORMALS[1].AsUInts.Length; j++)
+					{
+						before.AsVec3s[sparseNORMALS[1].AsUInts[j]] = sparseNORMALS[0].AsVec3s[j];
+					}
+					att["NORMAL"].AccessorContent = before;
+				}
+
+				if (sparsePOSITIONS != null)
+				{
+					NumericArray before = new NumericArray();
+					before.AsVec3s = new GLTF.Math.Vector3[att["POSITION"].AccessorContent.AsVec3s.Length];
+					for (int j = 0; j < sparsePOSITIONS[1].AsUInts.Length; j++)
+					{
+						before.AsVec3s[sparsePOSITIONS[1].AsUInts[j]] = sparsePOSITIONS[0].AsVec3s[j];
+					}
+					att["POSITION"].AccessorContent = before;
+				}
+
+				if (sparseTANGENTS != null)
+				{
+					NumericArray before = new NumericArray();
+					before.AsVec3s = new GLTF.Math.Vector3[att["TANGENT"].AccessorContent.AsVec3s.Length];
+
+					for (int j = 0; j < sparseTANGENTS[1].AsUInts.Length; j++)
+					{
+						before.AsVec3s[sparseTANGENTS[1].AsUInts[j]] = sparseTANGENTS[0].AsVec3s[j];
+					}
+					att["TANGENT"].AccessorContent = before;
+				}
 				TransformTargets(ref att);
 			}
+		}
+
+		private void GetTypeDetails(GLTFComponentType type, out uint componentSize, out float maxValue)
+		{
+			componentSize = 1;
+			maxValue = byte.MaxValue;
+
+			switch (type)
+			{
+				case GLTFComponentType.Byte:
+					componentSize = sizeof(sbyte);
+					maxValue = sbyte.MaxValue;
+					break;
+				case GLTFComponentType.UnsignedByte:
+					componentSize = sizeof(byte);
+					maxValue = byte.MaxValue;
+					break;
+				case GLTFComponentType.Short:
+					componentSize = sizeof(short);
+					break;
+				case GLTFComponentType.UnsignedShort:
+					componentSize = sizeof(ushort);
+					break;
+				case GLTFComponentType.UnsignedInt:
+					componentSize = sizeof(uint);
+					maxValue = uint.MaxValue;
+					break;
+				case GLTFComponentType.Float:
+					componentSize = sizeof(float);
+					maxValue = float.MaxValue;
+					break;
+				default:
+					throw new Exception("Unsupported component type.");
+			}
+		}
+		public GLTF.Math.Vector4[] AsSparseVector4Array(Accessor paraAccessor, ref NumericArray contents, byte[] bufferViewData, uint offset, bool normalizeIntValues = true)
+		{
+
+			var arr = new GLTF.Math.Vector4[paraAccessor.Sparse.Count];
+			var totalByteOffset = paraAccessor.Sparse.Values.ByteOffset + offset;
+
+			uint componentSize;
+			float maxValue;
+			GetTypeDetails(paraAccessor.ComponentType, out componentSize, out maxValue);
+			uint stride = componentSize * 4;
+			if (normalizeIntValues) maxValue = 1;
+
+			for (uint idx = 0; idx < paraAccessor.Sparse.Count; idx++)
+			{
+				if (paraAccessor.ComponentType == GLTFComponentType.Float)
+				{
+					arr[idx].X = BitConverter.ToSingle(bufferViewData, (int)(totalByteOffset + idx * stride + componentSize * 0));
+					arr[idx].Y = BitConverter.ToSingle(bufferViewData, (int)(totalByteOffset + idx * stride + componentSize * 1));
+					arr[idx].Z = BitConverter.ToSingle(bufferViewData, (int)(totalByteOffset + idx * stride + componentSize * 2));
+					arr[idx].W = BitConverter.ToSingle(bufferViewData, (int)(totalByteOffset + idx * stride + componentSize * 3));
+				}
+			}
+
+			contents.AsVec4s = arr;
+			return arr;
+		}
+		public GLTF.Math.Vector3[] AsSparseVector3Array(Accessor paraAccessor, ref NumericArray contents, byte[] bufferViewData, uint offset, bool normalizeIntValues = true)
+		{
+			var arr = new GLTF.Math.Vector3[paraAccessor.Sparse.Count];
+			var totalByteOffset = paraAccessor.Sparse.Values.ByteOffset + offset;
+			uint componentSize;
+			float maxValue;
+			GetTypeDetails(paraAccessor.ComponentType, out componentSize, out maxValue);
+			uint stride = componentSize * 3;
+			if (normalizeIntValues) maxValue = 1;
+			for (uint idx = 0; idx < paraAccessor.Sparse.Count; idx++)
+			{
+				if (paraAccessor.ComponentType == GLTFComponentType.Float)
+				{
+					arr[idx].X = BitConverter.ToSingle(bufferViewData, (int)(totalByteOffset + idx * stride + componentSize * 0));
+					arr[idx].Y = BitConverter.ToSingle(bufferViewData, (int)(totalByteOffset + idx * stride + componentSize * 1));
+					arr[idx].Z = BitConverter.ToSingle(bufferViewData, (int)(totalByteOffset + idx * stride + componentSize * 2));
+				}
+			}
+			contents.AsVec3s = arr;
+			return arr;
+		}
+		public uint[] AsSparseUIntArray(Accessor paraAccessor, ref NumericArray contents, byte[] bufferViewData, uint offset)
+		{
+			var arr = new uint[paraAccessor.Sparse.Count];
+			var totalByteOffset = paraAccessor.Sparse.Indices.ByteOffset + offset;
+			uint componentSize;
+			float maxValue;
+
+			GetTypeDetails(paraAccessor.Sparse.Indices.ComponentType, out componentSize, out maxValue);
+
+			uint stride = componentSize;
+			for (uint idx = 0; idx < paraAccessor.Sparse.Count; idx++)
+			{
+				if (stride == 1)
+				{
+					arr[idx] = (uint)bufferViewData[(int)(totalByteOffset + idx)];
+				}
+				else
+				{
+					arr[idx] = BitConverter.ToUInt16(bufferViewData, (int)(totalByteOffset + idx * stride));
+				}
+			}
+			contents.AsUInts = arr;
+			return arr;
+		}
+		private static uint LoadBufferView(BufferView bufferView, uint Offset, Stream Stream, out byte[] bufferViewCache)
+		{
+			uint totalOffset = bufferView.ByteOffset + Offset;
+
+#if !NETFX_CORE
+			if (Stream is System.IO.MemoryStream)
+			{
+
+				MemoryStream memoryStream = (MemoryStream)Stream;
+#if NETFX_CORE || NETSTANDARD1_3
+				if (memoryStream.TryGetBuffer(out System.ArraySegment<byte> arraySegment))
+				{
+					bufferViewCache = arraySegment.Array;
+					return totalOffset;
+				}
+			Debug.Log("LoadBufferView1 " + bufferView.ByteOffset);
+
+#else
+				bufferViewCache = memoryStream.GetBuffer();
+				return totalOffset;
+#endif
+			}
+#endif
+			Stream.Position = totalOffset;
+			bufferViewCache = new byte[bufferView.ByteLength];
+
+			// stream.Read only accepts int for length
+			uint remainingSize = bufferView.ByteLength;
+			while (remainingSize != 0)
+			{
+
+				int sizeToLoad = (int)System.Math.Min(remainingSize, int.MaxValue);
+				Stream.Read(bufferViewCache, (int)(bufferView.ByteLength - remainingSize), sizeToLoad);
+				remainingSize -= (uint)sizeToLoad;
+			}
+			return 0;
 		}
 
 		// Flip vectors to Unity coordinate system


### PR DESCRIPTION
Hello, I am jeoungju kim, an employee of the graphic development team of Samsung Electronics Mobile Division.

This project has some fatal errors as well as issues with sparse accessors. So I share my edits.
The three modifications are:

1. Fix sparse accessor parsing error (Failing to deserialize sparse accessors #587)
2. Modified to support up to 2 joints
3. Modified to load accessors of Morph Targets with sparse accessors without bufferView