### PR TITLE
GLTFSceneImporter: handles the case where the mesh has 0 vertice.

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
@@ -1398,7 +1398,7 @@ namespace UnityGLTF
 				}
 			}
 
-			if (node.Mesh != null)
+			if (node.Mesh != null && node.Mesh.Value.Primitives != null)
 			{
 				var mesh = node.Mesh.Value;
 				await ConstructMesh(mesh, node.Mesh.Id, cancellationToken);


### PR DESCRIPTION
Avoid load exception.