### PR TITLE
Fix keyframe filtering

### DIFF
--- a/Runtime/Scripts/Timeline/GLTFRecorder.cs
+++ b/Runtime/Scripts/Timeline/GLTFRecorder.cs
@@ -247,17 +247,18 @@ namespace UnityGLTF.Timeline
 						return;
 					// As a memory optimization we want to be able to skip identical samples.
 					// But, we cannot always skip samples when they are identical to the previous one - otherwise cases like this break:
-					// - First assume an object is invisible at first (by having a scale of (0,0,0)
-					// - At some point in time, it is set "visible" by updating its scale from (0,0,0) to (1,1,1)
-					// If we simply skipped identical samples on insert, instead of instantaneous
+					// - First assume an object is invisible at first (by having a scale of (0,0,0))
+					// - At some point in time, it is instantaneously set "visible" by updating its scale from (0,0,0) to (1,1,1)
+					// If we simply skip identical samples on insert, instead of a instantaneous
 					// visibility/scale changes we get a linearly interpolated scale change because only two samples will be recorded:
 					// - one (0,0,0) at the start of time
 					// - (1,1,1) at the time of the visibility change
 					// What we want to get is
 					// - one sample with (0,0,0) at the start,
 					// - one with the same value right before the instantaneous change,
-					// - and then directly after the change, we need a sample with (1,1,1)
-					
+					// - and then at the time of the change, we need a sample with (1,1,1)
+					// With this setup, now the linear interpolation only has an effect in the very short duration between the last two samples and we get the animation we want.
+
 					// How do we achieve both?
 					// Always sample & record and then on adding the next sample(s) we check
 					// if the *last two* samples were identical to the current sample.

--- a/Runtime/Scripts/Timeline/GLTFRecorder.cs
+++ b/Runtime/Scripts/Timeline/GLTFRecorder.cs
@@ -236,19 +236,16 @@ namespace UnityGLTF.Timeline
 					this.tr = tr;
 					this.plan = plan;
 					samples = new Dictionary<double, object>();
-					SampleIfChanged(time);
+					SampleTrack(time);
 				}
 
-				public void SampleIfChanged(double time)
+				public void SampleTrack(double time)
 				{
 					var value = plan.Sample(tr);
 					if (value == null || (value is Object o && !o))
 						return;
-					if (!value.Equals(lastSample))
-					{
-						samples[time] = value;
-						lastSample = value;
-					}
+					samples[time] = value;
+					lastSample = value;
 				}
 				
 			}
@@ -257,7 +254,7 @@ namespace UnityGLTF.Timeline
 			{
 				foreach (var track in tracks)
 				{
-					track.SampleIfChanged(time);
+					track.SampleTrack(time);
 				}
 			}
 		}

--- a/Runtime/Scripts/Timeline/GLTFRecorder.cs
+++ b/Runtime/Scripts/Timeline/GLTFRecorder.cs
@@ -245,17 +245,23 @@ namespace UnityGLTF.Timeline
 					var value = plan.Sample(tr);
 					if (value == null || (value is Object o && !o))
 						return;
-					// We cannot skip samples altogether when they are identical to the previous one - otherwise cases like this break:
-					// - First Set something "visible" by updating its scale from (0,0,0) to (1,1,1) at some point in time
-					// - an arbitrary time later set its visibility back to (0,0,0)
-					// - if we simply skipped identical samples, instead of instantaneous
-					// visibility/scale changes we get a linearly interpolated scale change for both "set visible" and "set invisible" 
-					//
-					// But as a memory optimization we may want to be able to skip identical samples.
+					// As a memory optimization we want to be able to skip identical samples.
+					// But, we cannot always skip samples when they are identical to the previous one - otherwise cases like this break:
+					// - First assume an object is invisible at first (by having a scale of (0,0,0)
+					// - At some point in time, it is set "visible" by updating its scale from (0,0,0) to (1,1,1)
+					// If we simply skipped identical samples on insert, instead of instantaneous
+					// visibility/scale changes we get a linearly interpolated scale change because only two samples will be recorded:
+					// - one (0,0,0) at the start of time
+					// - (1,1,1) at the time of the visibility change
+					// What we want to get is
+					// - one sample with (0,0,0) at the start,
+					// - one with the same value right before the instantaneous change,
+					// - and then directly after the change, we need a sample with (1,1,1)
+					
 					// How do we achieve both?
-					// Strategy is to always sample first and then on adding the next sample we check
+					// Always sample & record and then on adding the next sample(s) we check
 					// if the *last two* samples were identical to the current sample.
-					// If that is the case we can remove/overwrite the middle sample with the new value
+					// If that is the case we can remove/overwrite the middle sample with the new value.
 					if (lastSample != null
 						&& secondToLastSample != null
 						&& lastSample.Item2.Equals(secondToLastSample.Item2)


### PR DESCRIPTION
Small fix pr that solves a problem with exporting animations from unity to gltf.
In particular, it changes how the `AnimationData.Track` class will handle identical consecutive samples.
The change is also explained in a comment in the code, so i am pasting that in here, since its more than enough explanation.
```
// As a memory optimization we want to be able to skip identical samples.
// But, we cannot always skip samples when they are identical to the previous one - otherwise cases like this break:
// - First assume an object is invisible at first (by having a scale of (0,0,0))
// - At some point in time, it is instantaneously set "visible" by updating its scale from (0,0,0) to (1,1,1)
// If we simply skip identical samples on insert, instead of a instantaneous
// visibility/scale changes we get a linearly interpolated scale change because only two samples will be recorded:
// - one (0,0,0) at the start of time
// - (1,1,1) at the time of the visibility change
// What we want to get is
// - one sample with (0,0,0) at the start,
// - one with the same value right before the instantaneous change,
// - and then at the time of the change, we need a sample with (1,1,1)
// With this setup, now the linear interpolation only has an effect in the very short duration between the last two samples and we get the animation we want.

// How do we achieve both?
// Always sample & record and then on adding the next sample(s) we check
// if the *last two* samples were identical to the current sample.
// If that is the case we can remove/overwrite the middle sample with the new value.
```