### PR TITLE
Fix: Don't write "buffers" property in json if buffers are all empty

### DIFF
--- a/Runtime/Plugins/GLTFSerialization/Schema/GLTFRoot.cs
+++ b/Runtime/Plugins/GLTFSerialization/Schema/GLTFRoot.cs
@@ -436,7 +436,7 @@ namespace GLTF.Schema
 				jsonWriter.WriteEndArray();
 			}
 
-			if (Buffers != null && Buffers.Count > 0)
+			if (Buffers != null && Buffers.Count > 0 && Buffers.Any(x => x.ByteLength > 0))
 			{
 				jsonWriter.WritePropertyName("buffers");
 				jsonWriter.WriteStartArray();


### PR DESCRIPTION
Added check if any buffer has bytes, otherwise don't write buffers property to json.