### PR TITLE
Feature: blendshape import > frame weight multiplier option

### DIFF
--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -92,6 +92,7 @@ namespace UnityGLTF
         [SerializeField] internal bool _generateLightmapUVs = false;
 	    [Tooltip("When false, the index of the BlendShape is used as name.")]
         [SerializeField] internal bool _importBlendShapeNames = true;
+	    [SerializeField] internal BlendShapeFrameWeightMultiplierSetting _blendShapeFrameWeightsMultiplier = new BlendShapeFrameWeightMultiplierSetting(BlendShapeFrameWeightMultiplierSetting.MultiplierOption.Multiplier_1);
         [SerializeField] internal GLTFImporterNormals _importNormals = GLTFImporterNormals.Import;
         [SerializeField] internal GLTFImporterNormals _importTangents = GLTFImporterNormals.Import;
         [SerializeField] internal AnimationMethod _importAnimations = AnimationMethod.Mecanim;
@@ -851,7 +852,8 @@ namespace UnityGLTF
 			    SwapUVs = _swapUvs,
 			    ImportNormals = _importNormals,
 			    ImportTangents = _importTangents,
-			    ImportBlendShapeNames = _importBlendShapeNames
+			    ImportBlendShapeNames = _importBlendShapeNames,
+			    BlendShapeFrameWeightMultiplier = _blendShapeFrameWeightsMultiplier
 		    };
 
 		    using (var stream = File.OpenRead(projectFilePath))

--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -92,7 +92,8 @@ namespace UnityGLTF
         [SerializeField] internal bool _generateLightmapUVs = false;
 	    [Tooltip("When false, the index of the BlendShape is used as name.")]
         [SerializeField] internal bool _importBlendShapeNames = true;
-	    [SerializeField] internal BlendShapeFrameWeightMultiplierSetting _blendShapeFrameWeightsMultiplier = new BlendShapeFrameWeightMultiplierSetting(BlendShapeFrameWeightMultiplierSetting.MultiplierOption.Multiplier_1);
+	    [Tooltip("Blend shape frame weight import multiplier. Default is 1. For compatibility with some FBX animations you may need to use 100.")]
+	    [SerializeField] internal BlendShapeFrameWeightMultiplierSetting _blendShapeFrameWeightsMultiplier = new BlendShapeFrameWeightMultiplierSetting(BlendShapeFrameWeightMultiplierSetting.MultiplierOption.Multiplier1);
         [SerializeField] internal GLTFImporterNormals _importNormals = GLTFImporterNormals.Import;
         [SerializeField] internal GLTFImporterNormals _importTangents = GLTFImporterNormals.Import;
         [SerializeField] internal AnimationMethod _importAnimations = AnimationMethod.Mecanim;

--- a/Editor/Scripts/GLTFImporterInspector.cs
+++ b/Editor/Scripts/GLTFImporterInspector.cs
@@ -86,6 +86,7 @@ namespace UnityGLTF
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._readWriteEnabled)), new GUIContent("Read/Write"));
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._generateColliders)));
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._importBlendShapeNames)));
+			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._blendShapeFrameWeightsMultiplier)));
 			
 			EditorGUILayout.Separator();
 			

--- a/Runtime/Scripts/GLTFComponent.cs
+++ b/Runtime/Scripts/GLTFComponent.cs
@@ -49,6 +49,7 @@ namespace UnityGLTF
 		public GLTFImporterNormals ImportNormals = GLTFImporterNormals.Import;
 		public GLTFImporterNormals ImportTangents = GLTFImporterNormals.Import;
 		public bool SwapUVs = false;
+		public BlendShapeFrameWeightMultiplierSetting blendShapeFrameWeightsMultiplier = new BlendShapeFrameWeightMultiplierSetting(BlendShapeFrameWeightMultiplierSetting.MultiplierOption.Multiplier_1);
 
 		private async void Start()
 		{

--- a/Runtime/Scripts/GLTFComponent.cs
+++ b/Runtime/Scripts/GLTFComponent.cs
@@ -49,7 +49,8 @@ namespace UnityGLTF
 		public GLTFImporterNormals ImportNormals = GLTFImporterNormals.Import;
 		public GLTFImporterNormals ImportTangents = GLTFImporterNormals.Import;
 		public bool SwapUVs = false;
-		public BlendShapeFrameWeightMultiplierSetting blendShapeFrameWeightsMultiplier = new BlendShapeFrameWeightMultiplierSetting(BlendShapeFrameWeightMultiplierSetting.MultiplierOption.Multiplier_1);
+		[Tooltip("Blend shape frame weight import multiplier. Default is 1. For compatibility with some FBX animations you may need to use 100.")]
+		public BlendShapeFrameWeightMultiplierSetting blendShapeFrameWeightsMultiplier = new BlendShapeFrameWeightMultiplierSetting(BlendShapeFrameWeightMultiplierSetting.MultiplierOption.Multiplier1);
 
 		private async void Start()
 		{

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -46,7 +46,7 @@ namespace UnityGLTF
 		public GLTFImporterNormals ImportTangents = GLTFImporterNormals.Import;
 		public bool ImportBlendShapeNames = true;
 
-		public BlendShapeFrameWeightMultiplierSetting BlendShapeFrameWeightMultiplier = new BlendShapeFrameWeightMultiplierSetting(BlendShapeFrameWeightMultiplierSetting.MultiplierOption.Multiplier_1);
+		public BlendShapeFrameWeightMultiplierSetting BlendShapeFrameWeightMultiplier = new BlendShapeFrameWeightMultiplierSetting(BlendShapeFrameWeightMultiplierSetting.MultiplierOption.Multiplier1);
 
 #if UNITY_EDITOR
 		public GLTFImportContext ImportContext = new GLTFImportContext(null, GLTFSettings.GetOrCreateSettings());

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -46,6 +46,8 @@ namespace UnityGLTF
 		public GLTFImporterNormals ImportTangents = GLTFImporterNormals.Import;
 		public bool ImportBlendShapeNames = true;
 
+		public BlendShapeFrameWeightMultiplierSetting BlendShapeFrameWeightMultiplier = new BlendShapeFrameWeightMultiplierSetting(BlendShapeFrameWeightMultiplierSetting.MultiplierOption.Multiplier_1);
+
 #if UNITY_EDITOR
 		public GLTFImportContext ImportContext = new GLTFImportContext(null, GLTFSettings.GetOrCreateSettings());
 #else

--- a/Runtime/Scripts/SceneImporter/BlendShapeFrameWeightMultiplierSetting.cs
+++ b/Runtime/Scripts/SceneImporter/BlendShapeFrameWeightMultiplierSetting.cs
@@ -11,58 +11,49 @@ namespace UnityGLTF
     {
         public enum MultiplierOption
         {
-            Multiplier_1 = 0,
-            Multiplier_100 = 1,
+            Multiplier1 = 0,
+            Multiplier100 = 1,
             Custom = 2
         }
 
-        public MultiplierOption Option;
         [SerializeField]
-        internal float customMultiplier;
+        internal MultiplierOption _option;
+        
+        [SerializeField]
+        internal float _multiplier;
         
         public BlendShapeFrameWeightMultiplierSetting(MultiplierOption option)
         {
-            this.Option = option;
-            this.customMultiplier = 0f;
+            _option = option;
+            _multiplier = 1;
         }
         
-        public BlendShapeFrameWeightMultiplierSetting(float customMultiplier)
+        public BlendShapeFrameWeightMultiplierSetting(float multiplier)
         {
-            this.Option = MultiplierOption.Custom;
-            this.customMultiplier = customMultiplier;
-        }
-		
-        public float CustomMultiplier
-        {
-            get
-            {
-                if (Option == MultiplierOption.Custom)
-                    return customMultiplier;
-                else
-                    return 0f;
-            }
-            set
-            {
-                Option = MultiplierOption.Custom;
-                customMultiplier = value;
-            }
+            _option = MultiplierOption.Custom;
+            _multiplier = multiplier;
         }
         
         public float Multiplier
         {
             get
             {
-                switch (Option)
+                switch (_option)
                 {
-                    case MultiplierOption.Multiplier_1:
+                    case MultiplierOption.Multiplier1:
                         return 1f;
-                    case MultiplierOption.Multiplier_100:
+                    case MultiplierOption.Multiplier100:
                         return 100f;
                     case MultiplierOption.Custom:
-                        return customMultiplier;
+                        return _multiplier;
                     default:
                         throw new NotImplementedException();
                 }
+            }
+            set
+            {
+                _option = MultiplierOption.Custom;
+                _multiplier = value;
             }
         }
         
@@ -79,16 +70,14 @@ namespace UnityGLTF
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            var weight = property.FindPropertyRelative("weight");
-
-            var option = property.FindPropertyRelative("Option");
-            var customValue = property.FindPropertyRelative("customMultiplier");
+            var option = property.FindPropertyRelative(nameof(BlendShapeFrameWeightMultiplierSetting._option));
+            var customValue = property.FindPropertyRelative(nameof(BlendShapeFrameWeightMultiplierSetting._multiplier));
 
             EditorGUI.BeginProperty(position, label, property);
             {
                 position.height = EditorGUIUtility.singleLineHeight;
                 
-                var newBlendShapeFrameWeightSettingIndex = EditorGUI.Popup(position, label.text, option.enumValueIndex, new[] {"Multiplier 1x (Default)", "Multiplier x100", "Custom"});
+                var newBlendShapeFrameWeightSettingIndex = EditorGUI.Popup(position, label.text, option.enumValueIndex, new[] {"1", "100", "Custom"});
                 if (newBlendShapeFrameWeightSettingIndex != option.enumValueIndex)
                 {
                     option.enumValueIndex = newBlendShapeFrameWeightSettingIndex;
@@ -98,7 +87,7 @@ namespace UnityGLTF
                 {
                     position.y += EditorGUIUtility.singleLineHeight;
                     EditorGUI.indentLevel++;
-                    customValue.floatValue = EditorGUI.FloatField(position, "Custom", customValue.floatValue);
+                    customValue.floatValue = EditorGUI.FloatField(position, new GUIContent("Custom", "Custom value used as multiplier for Blend Shape frame weights on import."), customValue.floatValue);
                     EditorGUI.indentLevel--;
                 }
             }
@@ -107,8 +96,7 @@ namespace UnityGLTF
         
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            var option = property.FindPropertyRelative("Option");
-
+            var option = property.FindPropertyRelative(nameof(BlendShapeFrameWeightMultiplierSetting._option));
             if (option.enumValueIndex == 2)
             {
                 return EditorGUIUtility.singleLineHeight * 2f;

--- a/Runtime/Scripts/SceneImporter/BlendShapeFrameWeightMultiplierSetting.cs
+++ b/Runtime/Scripts/SceneImporter/BlendShapeFrameWeightMultiplierSetting.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace UnityGLTF
+{
+    [Serializable]
+    public struct BlendShapeFrameWeightMultiplierSetting
+    {
+        public enum MultiplierOption
+        {
+            Multiplier_1 = 0,
+            Multiplier_100 = 1,
+            Custom = 2
+        }
+
+        public MultiplierOption Option;
+        [SerializeField]
+        internal float customMultiplier;
+        
+        public BlendShapeFrameWeightMultiplierSetting(MultiplierOption option)
+        {
+            this.Option = option;
+            this.customMultiplier = 0f;
+        }
+        
+        public BlendShapeFrameWeightMultiplierSetting(float customMultiplier)
+        {
+            this.Option = MultiplierOption.Custom;
+            this.customMultiplier = customMultiplier;
+        }
+		
+        public float CustomMultiplier
+        {
+            get
+            {
+                if (Option == MultiplierOption.Custom)
+                    return customMultiplier;
+                else
+                    return 0f;
+            }
+            set
+            {
+                Option = MultiplierOption.Custom;
+                customMultiplier = value;
+            }
+        }
+        
+        public float Multiplier
+        {
+            get
+            {
+                switch (Option)
+                {
+                    case MultiplierOption.Multiplier_1:
+                        return 1f;
+                    case MultiplierOption.Multiplier_100:
+                        return 100f;
+                    case MultiplierOption.Custom:
+                        return customMultiplier;
+                    default:
+                        throw new NotImplementedException();
+                }
+            }
+        }
+        
+        public static implicit operator float(BlendShapeFrameWeightMultiplierSetting weightMultiplierSetting)
+        {
+            return weightMultiplierSetting.Multiplier;
+        }
+    }
+    
+#if UNITY_EDITOR
+    
+    [CustomPropertyDrawer(typeof(BlendShapeFrameWeightMultiplierSetting))]
+    public class BlendShapeFrameWeightMultiplierSettingDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            var weight = property.FindPropertyRelative("weight");
+
+            var option = property.FindPropertyRelative("Option");
+            var customValue = property.FindPropertyRelative("customMultiplier");
+
+            EditorGUI.BeginProperty(position, label, property);
+            {
+                position.height = EditorGUIUtility.singleLineHeight;
+                
+                var newBlendShapeFrameWeightSettingIndex = EditorGUI.Popup(position, label.text, option.enumValueIndex, new[] {"Multiplier 1x (Default)", "Multiplier x100", "Custom"});
+                if (newBlendShapeFrameWeightSettingIndex != option.enumValueIndex)
+                {
+                    option.enumValueIndex = newBlendShapeFrameWeightSettingIndex;
+                }
+
+                if (newBlendShapeFrameWeightSettingIndex == 2)
+                {
+                    position.y += EditorGUIUtility.singleLineHeight;
+                    EditorGUI.indentLevel++;
+                    customValue.floatValue = EditorGUI.FloatField(position, "Custom", customValue.floatValue);
+                    EditorGUI.indentLevel--;
+                }
+            }
+            EditorGUI.EndProperty();
+        }
+        
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            var option = property.FindPropertyRelative("Option");
+
+            if (option.enumValueIndex == 2)
+            {
+                return EditorGUIUtility.singleLineHeight * 2f;
+            }
+            return EditorGUIUtility.singleLineHeight;
+        }
+    }
+    
+#endif
+}

--- a/Runtime/Scripts/SceneImporter/BlendShapeFrameWeightMultiplierSetting.cs.meta
+++ b/Runtime/Scripts/SceneImporter/BlendShapeFrameWeightMultiplierSetting.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9df89f3f8d3645f3b4150e95b864974d
+timeCreated: 1706174663

--- a/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
@@ -347,13 +347,14 @@ namespace UnityGLTF
 								propertyNames[i] = _options.ImportBlendShapeNames ? ("blendShape." + ((targetNames != null && targetNames.Count > i) ? targetNames[i] : ("Morphtarget" + i))) : "blendShape."+i.ToString();
 							var frameFloats = new float[targetCount];
 
+							var blendShapeFrameWeight = _options.BlendShapeFrameWeightMultiplier;
 							SetAnimationCurve(clip, relativePath, propertyNames, input, output,
 								samplerCache.Interpolation, typeof(SkinnedMeshRenderer),
 								(data, frame) =>
 								{
 									var allValues = data.AsFloats;
 									for (var k = 0; k < targetCount; k++)
-										frameFloats[k] = allValues[frame * targetCount + k];
+										frameFloats[k] = allValues[frame * targetCount + k] * blendShapeFrameWeight;
 
 									return frameFloats;
 								});

--- a/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -561,7 +561,7 @@ namespace UnityGLTF
 				for (int i = 0; i < firstPrim.Targets.Count; i++)
 				{
 					var targetName = _options.ImportBlendShapeNames ? ((gltfMesh.TargetNames != null && gltfMesh.TargetNames.Count > i) ? gltfMesh.TargetNames[i] : $"Morphtarget{i}") : i.ToString();
-					mesh.AddBlendShapeFrame(targetName, 1f,
+					mesh.AddBlendShapeFrame(targetName, 1f * _options.BlendShapeFrameWeightMultiplier,
 						unityMeshData.MorphTargetVertices[i],
 						unityMeshData.MorphTargetNormals != null ? unityMeshData.MorphTargetNormals[i] : null,
 						unityMeshData.MorphTargetTangents != null ? unityMeshData.MorphTargetTangents[i] : null


### PR DESCRIPTION
New option for importing blendshapes:
- Adjustable frame weight multiplier (default is 1x)

When using other animation on a gltf model with blendshapes, it can be helpful to adjust the range for the blendshapes (eg. 0...1 or 0..100)