### PR TITLE
Updated dependent shadergraph version to 10.10.1 for OpenUPM install problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "2.0.0",
     "com.unity.modules.imageconversion": "1.0.0",
-    "com.unity.shadergraph": "10.0.0"
+    "com.unity.shadergraph": "10.10.1"
   },
   "samples": [
     {


### PR DESCRIPTION
https://github.com/KhronosGroup/UnityGLTF/issues/704

The version of dependent shader graph  is not valid for OpenUPM install.

com.unity.shadergraph@10.0.0 is not vaild
com.unity.shadergraph@10.10.1 is OK

```
openupm add org.khronos.unitygltf

WARN 404 version 10.0.0 is not a valid choice of 0.1.8, 0.1.9, 0.1.17, 1.0.0-beta, 1.1.1-preview, 1.1.2-preview, 1.1.3-preview, 1.1.4-preview, 1.1.6-preview, 1.1.9-preview, 1.1.8-preview, 1.1.5-preview, 2.0.1-preview, 2.0.3-preview, 2.0.4-preview, 2.0.4-preview.1, 2.0.5-preview, 3.0.0-preview, 2.0.6-preview, 2.0.7-preview, 2.0.8-preview, 3.1.0-preview, 3.3.0-preview, 4.0.0-preview, 4.0.1-preview, 5.0.0-preview, 4.1.0-preview, 4.2.0-preview, 5.1.0, 4.3.0-preview, 5.2.0, 5.2.1, 5.2.2, 4.6.0-preview, 5.2.3, 4.8.0-preview, 4.9.0-preview, 5.3.1, 4.10.0-preview, 5.6.1, 5.7.2, 5.8.2, 5.9.0, 5.10.0, 5.13.0, 6.5.3, 6.5.2, 6.7.1, 5.16.1, 6.9.0, 7.0.0, 7.0.1, 6.9.1, 7.1.1, 7.1.2, 6.9.2, 7.1.5, 7.1.6, 7.1.7, 7.1.8, 7.2.0, 7.2.1, 8.0.1, 7.3.1, 9.0.0-preview.14, 8.1.0, 7.4.1, 9.0.0-preview.34, 8.2.0, 10.0.0-preview.27, 7.4.2, 7.4.3, 9.0.0-preview.55, 7.5.1, 10.1.0, 9.0.0-preview.72, 10.2.0, 8.3.1, 10.2.1, 7.5.2, 10.2.2, 10.3.1, 7.5.3, 10.3.2, 10.4.0, 7.6.0, 10.5.0, 7.7.0, 10.5.1, 10.6.0, 7.7.1, 10.7.0, 10.8.0, 10.8.1, 10.9.0, 10.10.0, 10.10.1
notice suggest to install com.unity.shadergraph@10.0.0 or a replaceable version manually
ERR! missing dependencies please resolve the issue or run with option -f to ignore the warning
```