### PR TITLE
Camera import support

### DIFF
--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -96,6 +96,7 @@ namespace UnityGLTF
 	    [SerializeField] internal BlendShapeFrameWeightSetting _blendShapeFrameWeight = new BlendShapeFrameWeightSetting(BlendShapeFrameWeightSetting.MultiplierOption.Multiplier1);
         [SerializeField] internal GLTFImporterNormals _importNormals = GLTFImporterNormals.Import;
         [SerializeField] internal GLTFImporterNormals _importTangents = GLTFImporterNormals.Import;
+        [SerializeField] internal CameraImportOption _importCamera = CameraImportOption.ImportAndCameraDisabled;
         [SerializeField] internal AnimationMethod _importAnimations = AnimationMethod.Mecanim;
         [SerializeField] internal bool _addAnimatorComponent = false;
         [SerializeField] internal bool _animationLoopTime = true;
@@ -868,7 +869,8 @@ namespace UnityGLTF
 			    ImportNormals = _importNormals,
 			    ImportTangents = _importTangents,
 			    ImportBlendShapeNames = _importBlendShapeNames,
-			    BlendShapeFrameWeight = _blendShapeFrameWeight
+			    BlendShapeFrameWeight = _blendShapeFrameWeight,
+			    CameraImport = _importCamera
 		    };
 
 		    using (var stream = File.OpenRead(projectFilePath))

--- a/Editor/Scripts/GLTFImporterInspector.cs
+++ b/Editor/Scripts/GLTFImporterInspector.cs
@@ -79,6 +79,7 @@ namespace UnityGLTF
 			EditorGUILayout.LabelField("Scene", EditorStyles.boldLabel);
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._removeEmptyRootObjects)));
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._scaleFactor)));
+			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._importCamera)));
 			// EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._maximumLod)), new GUIContent("Maximum Shader LOD"));
 			EditorGUILayout.Separator();
 			

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -999,22 +999,22 @@ namespace UnityGLTF
 						if (node.Skin != null)
 							await SetupBones(node.Skin.Value, renderer, cancellationToken);
 
-					// morph target weights
-					if (weights != null)
-					{
-						for (int i = 0; i < weights.Count; ++i)
+						// morph target weights
+						if (weights != null)
 						{
-							renderer.SetBlendShapeWeight(i, (float)(weights[i] * _options.BlendShapeFrameWeight));
+							for (int i = 0; i < weights.Count; ++i)
+							{
+								renderer.SetBlendShapeWeight(i, (float)(weights[i] * _options.BlendShapeFrameWeight));
+							}
 						}
 					}
-				}
-				else
-				{
-					var filter = nodeObj.AddComponent<MeshFilter>();
-					filter.sharedMesh = unityMesh;
-					var renderer = nodeObj.AddComponent<MeshRenderer>();
-					renderer.sharedMaterials = materials;
-				}
+					else
+					{
+						var filter = nodeObj.AddComponent<MeshFilter>();
+						filter.sharedMesh = unityMesh;
+						var renderer = nodeObj.AddComponent<MeshRenderer>();
+						renderer.sharedMaterials = materials;
+					}
 
 #if UNITY_PHYSICS
 					if (!onlyMesh)
@@ -1047,14 +1047,6 @@ namespace UnityGLTF
 				}
 				
 				await ConstructLods(_gltfRoot, nodeObj, node, nodeIndex, cancellationToken);
-
-				/* TODO: implement camera (probably a flag to disable for VR as well)
-				if (camera != null)
-				{
-					GameObject cameraObj = camera.Value.Create();
-					cameraObj.transform.parent = nodeObj.transform;
-				}
-				*/
 
 				ConstructLights(nodeObj, node);
 				ConstructCamera(nodeObj, node);
@@ -1128,8 +1120,7 @@ namespace UnityGLTF
 				unityCamera.farClipPlane = (float)camera.Orthographic.ZFar;
 				unityCamera.nearClipPlane = (float)camera.Orthographic.ZNear;
 			}
-			else
-			if (camera.Perspective != null)
+			else if (camera.Perspective != null)
 			{
 				unityCamera = nodeObj.AddComponent<Camera>();
 				unityCamera.orthographic = false;

--- a/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -151,6 +151,9 @@ namespace UnityGLTF
 
 		protected void PrepareUnityMeshData()
 		{
+			if (_gltfRoot.Meshes == null)
+				return;
+			
 			for (int i = 0; i < _gltfRoot.Meshes.Count(); i++)
 			{
 				int meshIndex = i;
@@ -886,6 +889,9 @@ namespace UnityGLTF
 
 		private void FreeUpAccessorContents()
 		{
+			if (_gltfRoot.Meshes == null)
+				return;
+			
 			for (int meshIndex = 0; meshIndex < _gltfRoot.Meshes.Count; meshIndex++)
 			{
 				var gltfMesh = _gltfRoot.Meshes[meshIndex];
@@ -919,6 +925,9 @@ namespace UnityGLTF
 
 		private async Task PreparePrimitiveAttributes()
 		{
+			if (_gltfRoot.Meshes == null)
+				return;
+			
 			for (int meshIndex = 0; meshIndex < _gltfRoot.Meshes.Count; meshIndex++)
 			{
 				if (_assetCache.MeshCache[meshIndex] == null)


### PR DESCRIPTION
Added support for importing Cameras.
Also includes a new import option for them:
- **None** > No cameras will be imported
- **ImportAndActive** > Import cameras and set them active/enabled
- **ImportAndCameraDisabled** > Import cameras and set the camera component to disabled

Test files: 
[CamerImport.zip](https://github.com/KhronosGroup/UnityGLTF/files/14849746/CamerImport.zip)
[CamerImport_WithAnimationPointer.zip](https://github.com/KhronosGroup/UnityGLTF/files/14849747/CamerImport_WithAnimationPointer.zip)


