### PR TITLE
Export guard / layer mask fix

### DIFF
--- a/Runtime/Scripts/GLTFSceneExportGuard.cs
+++ b/Runtime/Scripts/GLTFSceneExportGuard.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace UnityGLTF
+{
+    // Empty implementation of IGLTFSceneExportGuard for use with editor.
+	public class GLTFSceneExportGuard : MonoBehaviour, IGLTFSceneExportGuard
+	{
+    }
+}

--- a/Runtime/Scripts/GLTFSceneExportGuard.cs
+++ b/Runtime/Scripts/GLTFSceneExportGuard.cs
@@ -2,8 +2,8 @@ using UnityEngine;
 
 namespace UnityGLTF
 {
-    // Empty implementation of IGLTFSceneExportGuard for use with editor.
+	// Empty implementation of IGLTFSceneExportGuard for use with editor.
 	public class GLTFSceneExportGuard : MonoBehaviour, IGLTFSceneExportGuard
 	{
-    }
+	}
 }

--- a/Runtime/Scripts/GLTFSceneExportGuard.cs.meta
+++ b/Runtime/Scripts/GLTFSceneExportGuard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42e734434e468b447a31d9cc5da41ccf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -95,11 +95,11 @@ namespace UnityGLTF
 #pragma warning restore CS0618 // Type or member is obsolete
 	}
 
-    // Empty interface to mark a portion of a transform hierarchy as unexportable.
-    public interface IGLTFSceneExportGuard
-    {
-        //
-    }
+	// Empty interface to mark a portion of a transform hierarchy as unexportable.
+	public interface IGLTFSceneExportGuard
+	{
+		//
+	}
 
 	[Obsolete("Use UnityGLTF.ExportContext instead. (UnityUpgradable) -> UnityGLTF.ExportContext")]
 	public class ExportOptions: ExportContext
@@ -976,9 +976,9 @@ namespace UnityGLTF
 
 			if (settings.UseMainCameraVisibility && (_exportLayerMask != 0 && _exportLayerMask != (_exportLayerMask | 1 << transform.gameObject.layer))) return false;
 			if (transform.CompareTag("EditorOnly")) return false;
-            if (transform.GetComponent<IGLTFSceneExportGuard>() != null) return false;
+			if (transform.GetComponent<IGLTFSceneExportGuard>() != null) return false;
 
-            return true;
+			return true;
 		}
 
 		private SceneId ExportScene(string name, Transform[] rootObjTransforms)

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -95,6 +95,12 @@ namespace UnityGLTF
 #pragma warning restore CS0618 // Type or member is obsolete
 	}
 
+    // Empty interface to mark a portion of a transform hierarchy as unexportable.
+    public interface IGLTFSceneExportGuard
+    {
+        //
+    }
+
 	[Obsolete("Use UnityGLTF.ExportContext instead. (UnityUpgradable) -> UnityGLTF.ExportContext")]
 	public class ExportOptions: ExportContext
 	{
@@ -967,9 +973,12 @@ namespace UnityGLTF
 			{
 				return false;
 			}
-			if (settings.UseMainCameraVisibility && (_exportLayerMask >= 0 && _exportLayerMask != (_exportLayerMask | 1 << transform.gameObject.layer))) return false;
+
+			if (settings.UseMainCameraVisibility && (_exportLayerMask != 0 && _exportLayerMask != (_exportLayerMask | 1 << transform.gameObject.layer))) return false;
 			if (transform.CompareTag("EditorOnly")) return false;
-			return true;
+            if (transform.GetComponent<IGLTFSceneExportGuard>() != null) return false;
+
+            return true;
 		}
 
 		private SceneId ExportScene(string name, Transform[] rootObjTransforms)


### PR DESCRIPTION
This PR has two relatively simple changes;

IGLTFSceneExportGuard - this interface allows a MonoBehaviour on a GameObject to mark a portion of the transform hierarchy as unexportable, which allows us to easily indicate that portions of a scene are for business logic only and not visible objects, without having to create new layers and/or adjust tags. I've also included GLTFSceneExportGuard which is an empty MonoBehaviour purely for convenience when using this feature within the editor.

On line 970, there's a check for _exportLayerMask >= 0. I assume this was written with the assumption that an empty layer mask would be nonsensical and the exporter should just default to all layers. However, if layer 31 is enabled, this sets the sign bit on the underlying int, which will make the layer mask negative, and it'll therefore fail this check. I've switched this to _exportLayerMask != 0.

Both of these changes have been tested by us internally. Please take a look - thanks!