### PR TITLE
Fixed wrong exported blendshape normals and tangents when using sparse accessors

### DIFF
--- a/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
@@ -431,7 +431,7 @@ namespace UnityGLTF
 						}
 						else
 						{
-							exportTargets.Add(SemanticProperties.NORMAL, ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaVertices, SchemaExtensions.CoordinateSpaceConversionScale)));
+							exportTargets.Add(SemanticProperties.NORMAL, ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaNormals, SchemaExtensions.CoordinateSpaceConversionScale)));
 						}
 					}
 					if (meshHasTangents && settings.BlendShapeExportProperties.HasFlag(GLTFSettings.BlendShapeExportPropertyFlags.Tangent))

--- a/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
@@ -414,7 +414,6 @@ namespace UnityGLTF
 						// - get the accessor we want to base this upon
 						// - this is how position is originally exported:
 						//   ExportAccessor(SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(meshObj.vertices, SchemaExtensions.CoordinateSpaceConversionScale));
-						var baseAccessor = _meshToPrims[meshObj].aPosition;
 						var exportedAccessor = ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaVertices, SchemaExtensions.CoordinateSpaceConversionScale));
 						if (exportedAccessor != null)
 						{
@@ -432,7 +431,6 @@ namespace UnityGLTF
 						}
 						else
 						{
-							var baseAccessor = _meshToPrims[meshObj].aNormal;
 							exportTargets.Add(SemanticProperties.NORMAL, ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaVertices, SchemaExtensions.CoordinateSpaceConversionScale)));
 						}
 					}
@@ -446,10 +444,7 @@ namespace UnityGLTF
 						}
 						else
 						{
-							// 	var baseAccessor = _meshToPrims[meshObj].aTangent;
-							// 	exportTargets.Add(SemanticProperties.TANGENT, ExportSparseAccessor(baseAccessor, SchemaExtensions.ConvertVector4CoordinateSpaceAndCopy(meshObj.tangents, SchemaExtensions.TangentSpaceConversionScale), SchemaExtensions.ConvertVector4CoordinateSpaceAndCopy(deltaVertices, SchemaExtensions.TangentSpaceConversionScale)));
-							exportTargets.Add(SemanticProperties.TANGENT, ExportAccessor(SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaTangents, SchemaExtensions.CoordinateSpaceConversionScale)));
-							// Debug.LogWarning("Blend Shape Tangents for " + meshObj + " won't be exported with sparse accessors – sparse accessor for tangents isn't supported right now.");
+							exportTargets.Add(SemanticProperties.TANGENT, ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaTangents, SchemaExtensions.CoordinateSpaceConversionScale)));
 						}
 					}
 					targets.Add(exportTargets);


### PR DESCRIPTION
Wrong accessor export method was used for exporting blendshape tangents with sparse, and fixed wrong deltaVertices was used instead of deltaNormals. 

![image](https://github.com/KhronosGroup/UnityGLTF/assets/118285915/78488b16-72a5-4abe-8950-293b40048931)
![image](https://github.com/KhronosGroup/UnityGLTF/assets/118285915/df1aa8ff-d97a-4794-b56c-bb9a47bc7b81)


Test Models:
[MorphWithNormalAndTangents.zip]https://github.com/KhronosGroup/UnityGLTF/files/14569743/MorphWithNormalAndTangents.zip)

[cubeToSphere.zip](https://github.com/KhronosGroup/UnityGLTF/files/14569498/cubeToSphere.zip)
