### PR TITLE
Removed synchronous wait in GLB json loading causing spikes

### DIFF
--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -594,15 +594,7 @@ namespace UnityGLTF
 			var dataLoader2 = _options.DataLoader as IDataLoader2;
 			if (IsMultithreaded && dataLoader2 != null)
 			{
-				Thread loadThread = new Thread(() => _gltfStream.Stream = dataLoader2.LoadStream(jsonFilePath));
-				loadThread.Priority = ThreadPriority.Highest;
-				loadThread.Start();
-				while (loadThread.IsAlive)
-				{
-					Debug.Log("GLB json data is loading async...");
-					await Task.Delay(25);
-				}
-				Debug.Log("GLB json data is loaded.");
+				await Task.Run(() => _gltfStream.Stream = dataLoader2.LoadStream(jsonFilePath));
 			}
 			else
 #endif
@@ -615,15 +607,7 @@ namespace UnityGLTF
 #if !WINDOWS_UWP && !UNITY_WEBGL
 			if (IsMultithreaded)
 			{
-				Thread parseJsonThread = new Thread(() => GLTFParser.ParseJson(_gltfStream.Stream, out _gltfRoot, _gltfStream.StartPosition));
-				parseJsonThread.Priority = ThreadPriority.Highest;
-				parseJsonThread.Start();
-				while (parseJsonThread.IsAlive)
-				{
-					Debug.Log("GLB json data is loading async...");
-					await Task.Delay(25);
-				}
-				Debug.Log("GLB json data is loaded.");
+				await Task.Run(() => GLTFParser.ParseJson(_gltfStream.Stream, out _gltfRoot, _gltfStream.StartPosition));
 				if (_gltfRoot == null)
 				{
 					throw new GLTFLoadException($"Failed to parse glTF (File: {_gltfFileName})");


### PR DESCRIPTION
The synchronous wait here was causing the main thread to wait until the JSON is loaded completely which was highly dependent on the device and was varying depending on it.

This new solution is also waiting synchronously but main thread doesn't wait for it.