### PR TITLE
Add initial support for MaterialX conversion through PolySpatial

### DIFF
--- a/Editor/Scripts/Internal/AvatarUtils.cs
+++ b/Editor/Scripts/Internal/AvatarUtils.cs
@@ -135,6 +135,33 @@ namespace UnityGLTF
 			{ "rightFoot", "RightFoot" },
 			{ "rightToes", "RightToes" },
 			// { "toesR_end", "" },
+			
+			// Meta Avatar
+			{"Hips_jnt", "Hips"},
+			{"SpineLower_jnt", "Spine"},
+			{"SpineMiddle_jnt", "Chest"},
+			{"Chest_jnt", "UpperChest"},
+			{"Neck_jnt", "Neck"},
+			{"Head_jnt", "Head"},
+			{"Jaw_jnt", "Jaw"},
+			{"LeftEye_jnt", "LeftEye"},
+			{"RightEye_jnt", "RightEye"},
+			{"LeftShoulder_jnt", "LeftShoulder"},
+			{"LeftArmUpper_jnt", "LeftUpperArm"},
+			{"LeftArmLower_jnt", "LeftLowerArm"},
+			{"LeftHandWrist_jnt", "LeftHand"},
+			{"RightShoulder_jnt", "RightShoulder"},
+			{"RightArmUpper_jnt", "RightUpperArm"},
+			{"RightArmLower_jnt", "RightLowerArm"},
+			{"RightHandWrist_jnt", "RightHand"},
+			{"LeftLegUpper_jnt", "LeftUpperLeg"},
+			{"LeftLegLower_jnt", "LeftLowerLeg"},
+			{"LeftFootBall_jnt", "LeftFoot"},
+			{"LeftFootToe_jnt", "LeftToes"},
+			{"RightLegUpper_jnt", "RightUpperLeg"},
+			{"RightLegLower_jnt", "RightLowerLeg"},
+			{"RightFootBall_jnt", "RightFoot"},
+			{"RightFootToe_jnt", "RightToes"}			
 
 		};
 

--- a/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
@@ -422,7 +422,6 @@ namespace UnityGLTF
 						// - get the accessor we want to base this upon
 						// - this is how position is originally exported:
 						//   ExportAccessor(SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(meshObj.vertices, SchemaExtensions.CoordinateSpaceConversionScale));
-						var baseAccessor = _meshToPrims[meshObj].aPosition;
 						var exportedAccessor = ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaVertices, SchemaExtensions.CoordinateSpaceConversionScale));
 						if (exportedAccessor != null)
 						{
@@ -440,8 +439,7 @@ namespace UnityGLTF
 						}
 						else
 						{
-							var baseAccessor = _meshToPrims[meshObj].aNormal;
-							exportTargets.Add(SemanticProperties.NORMAL, ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaVertices, SchemaExtensions.CoordinateSpaceConversionScale)));
+							exportTargets.Add(SemanticProperties.NORMAL, ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaNormals, SchemaExtensions.CoordinateSpaceConversionScale)));
 						}
 					}
 					if (meshHasTangents && settings.BlendShapeExportProperties.HasFlag(GLTFSettings.BlendShapeExportPropertyFlags.Tangent))
@@ -454,10 +452,7 @@ namespace UnityGLTF
 						}
 						else
 						{
-							// 	var baseAccessor = _meshToPrims[meshObj].aTangent;
-							// 	exportTargets.Add(SemanticProperties.TANGENT, ExportSparseAccessor(baseAccessor, SchemaExtensions.ConvertVector4CoordinateSpaceAndCopy(meshObj.tangents, SchemaExtensions.TangentSpaceConversionScale), SchemaExtensions.ConvertVector4CoordinateSpaceAndCopy(deltaVertices, SchemaExtensions.TangentSpaceConversionScale)));
-							exportTargets.Add(SemanticProperties.TANGENT, ExportAccessor(SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaTangents, SchemaExtensions.CoordinateSpaceConversionScale)));
-							// Debug.LogWarning("Blend Shape Tangents for " + meshObj + " won't be exported with sparse accessors – sparse accessor for tangents isn't supported right now.");
+							exportTargets.Add(SemanticProperties.TANGENT, ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaTangents, SchemaExtensions.CoordinateSpaceConversionScale)));
 						}
 					}
 					targets.Add(exportTargets);

--- a/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
@@ -138,10 +138,10 @@ namespace UnityGLTF
 
 						SetTransformKeyword();
 					}
-					else
-					if (IsTextureFlipped(textureId.Value))
+					else if (IsTextureFlipped(textureId.Value))
 					{
-						mrMapper.BaseColorXScale *= new Vector2(1f,-1f);
+						mrMapper.BaseColorXScale = new Vector2(1f,-1f);
+						mrMapper.BaseColorXOffset = new Vector2(0f, 1f);
 						SetTransformKeyword();
 					}
 				}
@@ -166,10 +166,10 @@ namespace UnityGLTF
 						if (ext.TexCoord != null) mrMapper.MetallicRoughnessXTexCoord = ext.TexCoord.Value;
 						SetTransformKeyword();
 					}
-					else
-					if (IsTextureFlipped(textureId.Value))
+					else if (IsTextureFlipped(textureId.Value))
 					{
-						mrMapper.MetallicRoughnessXScale *= new Vector2(1f,-1f);
+						mrMapper.MetallicRoughnessXScale = new Vector2(1f,-1f);
+						mrMapper.MetallicRoughnessXOffset = new Vector2(0f, 1f);
 						SetTransformKeyword();
 					}
 				}
@@ -219,10 +219,10 @@ namespace UnityGLTF
 						MatHelper.SetKeyword(mapper.Material, "_TEXTURE_TRANSFORM", true);
 						SetTransformKeyword();
 					}
-					else
-					if (IsTextureFlipped(textureId.Value))
+					else if (IsTextureFlipped(textureId.Value))
 					{
-						sgMapper.DiffuseXScale *= new Vector2(1f,-1f);
+						sgMapper.DiffuseXScale = new Vector2(1f,-1f);
+						sgMapper.DiffuseXOffset = new Vector2(0f, 1f);
 						SetTransformKeyword();
 					}
 				}
@@ -247,10 +247,10 @@ namespace UnityGLTF
 						if (ext.TexCoord != null) sgMapper.SpecularGlossinessXTexCoord = ext.TexCoord.Value;
 						SetTransformKeyword();
 					}
-					else
-					if (IsTextureFlipped(textureId.Value))
+					else if (IsTextureFlipped(textureId.Value))
 					{
-						sgMapper.SpecularGlossinessXScale *= new Vector2(1f,-1f);
+						sgMapper.SpecularGlossinessXScale = new Vector2(1f,-1f);
+						sgMapper.SpecularGlossinessXOffset = new Vector2(0f, 1f);
 						SetTransformKeyword();
 					}
 				}
@@ -279,10 +279,10 @@ namespace UnityGLTF
 						if (ext.TexCoord != null) unlitMapper.BaseColorXTexCoord = ext.TexCoord.Value;
 						SetTransformKeyword();
 					}
-					else
-					if (IsTextureFlipped(textureId.Value))
+					else if (IsTextureFlipped(textureId.Value))
 					{
-						unlitMapper.BaseColorXScale *= new Vector2(1f,-1f);
+						unlitMapper.BaseColorXScale = new Vector2(1f,-1f);
+						unlitMapper.BaseColorXOffset = new Vector2(0f, 1f);
 						SetTransformKeyword();
 					}
 				}
@@ -321,10 +321,10 @@ namespace UnityGLTF
 							if (td.TexCoordExtra != null) transmissionMapper.TransmissionTextureTexCoord = td.TexCoordExtra.Value;
 							SetTransformKeyword();
 						}
-						else
-						if (IsTextureFlipped(transmission.transmissionTexture.Index.Value))
+						else if (IsTextureFlipped(transmission.transmissionTexture.Index.Value))
 						{
-							transmissionMapper.TransmissionTextureScale *= new Vector2(1f,-1f);
+							transmissionMapper.TransmissionTextureScale = new Vector2(1f,-1f);
+							transmissionMapper.TransmissionTextureOffset = new Vector2(0f, 1f);
 							SetTransformKeyword();
 						}
 					}
@@ -359,10 +359,10 @@ namespace UnityGLTF
 							if (td.TexCoordExtra != null) volumeMapper.ThicknessTextureTexCoord = td.TexCoordExtra.Value;
 							SetTransformKeyword();
 						}
-						else
-						if (IsTextureFlipped(volume.thicknessTexture.Index.Value))
+						else if (IsTextureFlipped(volume.thicknessTexture.Index.Value))
 						{
-							volumeMapper.ThicknessTextureScale *= new Vector2(1f,-1f);
+							volumeMapper.ThicknessTextureScale = new Vector2(1f,-1f);
+							volumeMapper.ThicknessTextureOffset = new Vector2(0f, 1f);
 							SetTransformKeyword();
 						}
 					}
@@ -397,10 +397,10 @@ namespace UnityGLTF
 							if (td.TexCoordExtra != null) iridescenceMapper.IridescenceTextureTexCoord = td.TexCoordExtra.Value;
 							SetTransformKeyword();
 						}
-						else
-						if (IsTextureFlipped(iridescence.iridescenceTexture.Index.Value))
+						else if (IsTextureFlipped(iridescence.iridescenceTexture.Index.Value))
 						{
-							iridescenceMapper.IridescenceTextureScale *= new Vector2(1f,-1f);
+							iridescenceMapper.IridescenceTextureScale = new Vector2(1f,-1f);
+							iridescenceMapper.IridescenceTextureOffset = new Vector2(0f, 1f);
 							SetTransformKeyword();
 						}
 					}
@@ -421,10 +421,10 @@ namespace UnityGLTF
 							if (td2.TexCoordExtra != null) iridescenceMapper.IridescenceThicknessTextureTexCoord = td2.TexCoordExtra.Value;
 							SetTransformKeyword();
 						}
-						else
-						if (IsTextureFlipped(iridescence.iridescenceThicknessTexture.Index.Value))
+						else if (IsTextureFlipped(iridescence.iridescenceThicknessTexture.Index.Value))
 						{
-							iridescenceMapper.IridescenceThicknessTextureScale *= new Vector2(1f, -1f);
+							iridescenceMapper.IridescenceThicknessTextureScale = new Vector2(1f, -1f);
+							iridescenceMapper.IridescenceThicknessTextureOffset = new Vector2(0f, 1f);
 							SetTransformKeyword();
 						}
 					}
@@ -457,10 +457,10 @@ namespace UnityGLTF
 							if (td.TexCoordExtra != null) specularMapper.SpecularTextureTexCoord = td.TexCoordExtra.Value;
 							SetTransformKeyword();
 						}
-						else
-						if (IsTextureFlipped(specular.specularTexture.Index.Value))
+						else if (IsTextureFlipped(specular.specularTexture.Index.Value))
 						{
-							specularMapper.SpecularTextureScale *= new Vector2(1f, -1f);
+							specularMapper.SpecularTextureScale = new Vector2(1f, -1f);
+							specularMapper.SpecularTextureOffset = new Vector2(0f, 1f);
 							SetTransformKeyword();
 						}
 					}
@@ -481,10 +481,10 @@ namespace UnityGLTF
 							if (td2.TexCoordExtra != null) specularMapper.SpecularColorTextureTexCoord = td2.TexCoordExtra.Value;
 							SetTransformKeyword();
 						}
-						else
-						if (IsTextureFlipped(specular.specularColorTexture.Index.Value))
+						else if (IsTextureFlipped(specular.specularColorTexture.Index.Value))
 						{
-							specularMapper.SpecularColorTextureScale *= new Vector2(1f, -1f);
+							specularMapper.SpecularColorTextureScale = new Vector2(1f, -1f);
+							specularMapper.SpecularColorTextureOffset = new Vector2(0f, 1f);
 							SetTransformKeyword();
 						}
 					}
@@ -517,10 +517,10 @@ namespace UnityGLTF
 							if (td.TexCoordExtra != null) clearcoatMapper.ClearcoatTextureTexCoord = td.TexCoordExtra.Value;
 							SetTransformKeyword();
 						}
-						else
-						if (IsTextureFlipped(clearcoat.clearcoatTexture.Index.Value))
+						else if (IsTextureFlipped(clearcoat.clearcoatTexture.Index.Value))
 						{
-							clearcoatMapper.ClearcoatTextureScale *= new Vector2(1f, -1f);
+							clearcoatMapper.ClearcoatTextureScale = new Vector2(1f, -1f);
+							clearcoatMapper.ClearcoatTextureOffset = new Vector2(0f, 1f);
 							SetTransformKeyword();
 						}
 					}
@@ -541,10 +541,10 @@ namespace UnityGLTF
 							if (td.TexCoordExtra != null) clearcoatMapper.ClearcoatRoughnessTextureTexCoord = td.TexCoordExtra.Value;
 							SetTransformKeyword();
 						}
-						else
-						if (IsTextureFlipped(clearcoat.clearcoatRoughnessTexture.Index.Value))
+						else if (IsTextureFlipped(clearcoat.clearcoatRoughnessTexture.Index.Value))
 						{
-							clearcoatMapper.ClearcoatRoughnessTextureScale *= new Vector2(1f, -1f);
+							clearcoatMapper.ClearcoatRoughnessTextureScale = new Vector2(1f, -1f);
+							clearcoatMapper.ClearcoatRoughnessTextureOffset = new Vector2(0f, 1f);
 							SetTransformKeyword();
 						}
 
@@ -575,7 +575,8 @@ namespace UnityGLTF
 							}
 							else if (IsTextureFlipped(clearcoat.clearcoatNormalTexture.Index.Value))
 							{
-								clearcoatNormalMapper.ClearcoatNormalTextureScale *= new Vector2(1f, -1f);
+								clearcoatNormalMapper.ClearcoatNormalTextureScale = new Vector2(1f, -1f);
+								clearcoatNormalMapper.ClearcoatNormalTextureOffset = new Vector2(0f, 1f);
 								SetTransformKeyword();
 							}
 						}
@@ -609,10 +610,10 @@ namespace UnityGLTF
 						if (ext.TexCoord != null) uniformMapper.NormalXTexCoord = ext.TexCoord.Value;
 						SetTransformKeyword();
 					}
-					else
-					if (IsTextureFlipped(textureId.Value))
+					else if (IsTextureFlipped(textureId.Value))
 					{
-						uniformMapper.NormalXScale *= new Vector2(1f,-1f);
+						uniformMapper.NormalXScale = new Vector2(1f,-1f);
+						uniformMapper.NormalXOffset = new Vector2(0f, 1f);
 						SetTransformKeyword();
 					}
 				}
@@ -634,10 +635,10 @@ namespace UnityGLTF
 						if (ext.TexCoord != null) uniformMapper.EmissiveXTexCoord = ext.TexCoord.Value;
 						SetTransformKeyword();
 					}
-					else
-					if (IsTextureFlipped(textureId.Value))
+					else if (IsTextureFlipped(textureId.Value))
 					{
-						uniformMapper.EmissiveXScale *= new Vector2(1f,-1f);
+						uniformMapper.EmissiveXScale = new Vector2(1f,-1f);
+						uniformMapper.EmissiveXOffset = new Vector2(0f, 1f);
 						SetTransformKeyword();
 					}
 				}
@@ -661,10 +662,10 @@ namespace UnityGLTF
 						if (ext.TexCoord != null) uniformMapper.OcclusionXTexCoord = ext.TexCoord.Value;
 						SetTransformKeyword();
 					}
-					else
-					if (IsTextureFlipped(textureId.Value))
+					else if (IsTextureFlipped(textureId.Value))
 					{
-						uniformMapper.OcclusionXScale *= new Vector2(1f,-1f);
+						uniformMapper.OcclusionXScale = new Vector2(1f,-1f);
+						uniformMapper.OcclusionXOffset = new Vector2(0f, 1f);
 						SetTransformKeyword();
 					}
 				}

--- a/Runtime/Scripts/SceneImporter/ImporterTextures.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterTextures.cs
@@ -164,9 +164,6 @@ namespace UnityGLTF
 						var resultTextureData = await ktxTexture.LoadFromBytes(data, isLinear);
 						texture = resultTextureData.texture;
 						texture.name = textureName;
-
-						ktxTexture.Dispose();
-
 					}
 					else
 #endif

--- a/Runtime/Shaders/ShaderGraph/TextureTransform.shadersubgraph
+++ b/Runtime/Shaders/ShaderGraph/TextureTransform.shadersubgraph
@@ -19,6 +19,9 @@
     "m_Keywords": [
         {
             "m_Id": "56d9a937ceac4565b9af6f99ea5e08d7"
+        },
+        {
+            "m_Id": "1d79aad20de94e19b191d087f66ad3a4"
         }
     ],
     "m_Dropdowns": [],
@@ -93,6 +96,15 @@
         },
         {
             "m_Id": "c1248bbb0c1f483089bbf98e64ff5d96"
+        },
+        {
+            "m_Id": "580e41aae5fd4e6793cd43b2fad1ac61"
+        },
+        {
+            "m_Id": "7b7b83eb4b5e43649c1c0e8735d3ccf0"
+        },
+        {
+            "m_Id": "b0b94af219dc47c38aee9594196909ff"
         }
     ],
     "m_GroupDatas": [],
@@ -191,9 +203,9 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "f0d3ab8b87c4459d8a6d9162da0b7386"
+                    "m_Id": "b0b94af219dc47c38aee9594196909ff"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 2
             }
         },
         {
@@ -202,26 +214,26 @@
                     "m_Id": "3456cd311347447c9af3c6631e485850"
                 },
                 "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "580e41aae5fd4e6793cd43b2fad1ac61"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "580e41aae5fd4e6793cd43b2fad1ac61"
+                },
+                "m_SlotId": 0
             },
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "9a922e6e719848598cb9ed1c4339773c"
                 },
                 "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "3456cd311347447c9af3c6631e485850"
-                },
-                "m_SlotId": 4
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "27b8e9e16e03474f92d540ae01c669d7"
-                },
-                "m_SlotId": 3
             }
         },
         {
@@ -248,6 +260,34 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "d8f8412f9a9c4488891fa54ee86d3c58"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "7b7b83eb4b5e43649c1c0e8735d3ccf0"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "3456cd311347447c9af3c6631e485850"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "7b7b83eb4b5e43649c1c0e8735d3ccf0"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "580e41aae5fd4e6793cd43b2fad1ac61"
                 },
                 "m_SlotId": 1
             }
@@ -297,6 +337,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "99cba88abd1448caa209aa4cf422b329"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "b0b94af219dc47c38aee9594196909ff"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "9a922e6e719848598cb9ed1c4339773c"
                 },
                 "m_SlotId": 2
@@ -306,6 +360,20 @@
                     "m_Id": "d8f8412f9a9c4488891fa54ee86d3c58"
                 },
                 "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "b0b94af219dc47c38aee9594196909ff"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "f0d3ab8b87c4459d8a6d9162da0b7386"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -334,6 +402,20 @@
                     "m_Id": "772e21e2ba714d92bc5aa9b55c1374b3"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "c1248bbb0c1f483089bbf98e64ff5d96"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "27b8e9e16e03474f92d540ae01c669d7"
+                },
+                "m_SlotId": 3
             }
         },
         {
@@ -678,6 +760,30 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "1c3a35fc49d048f28b5744c3a19eca4b",
+    "m_Id": 2,
+    "m_DisplayName": "Off",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Off",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "1d24fdf3c309414d889eb8f58ffe0b35",
     "m_Id": 1,
     "m_DisplayName": "On",
@@ -697,6 +803,47 @@
         "z": 0.0,
         "w": 0.0
     }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "1d79aad20de94e19b191d087f66ad3a4",
+    "m_Guid": {
+        "m_GuidSerialized": "1d5b1a6a-75f0-450b-9a60-e35df192360a"
+    },
+    "m_Name": "MaterialX",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "MaterialX",
+    "m_DefaultReferenceName": "MATERIALX",
+    "m_OverrideReferenceName": "MATERIAL_X",
+    "m_GeneratePropertyBlock": false,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_KeywordType": 0,
+    "m_KeywordDefinition": 2,
+    "m_KeywordScope": 1,
+    "m_KeywordStages": 63,
+    "m_Entries": [],
+    "m_Value": 0,
+    "m_IsEditable": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "1ec7191752204f0ba54cbb5611c2e9b0",
+    "m_Id": 4,
+    "m_DisplayName": "W",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "W",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [
+        "W"
+    ]
 }
 
 {
@@ -851,10 +998,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 767.0001220703125,
-            "y": -155.99998474121095,
-            "width": 142.99993896484376,
-            "height": 100.99995422363281
+            "x": 911.5001831054688,
+            "y": -842.5000610351563,
+            "width": 142.50006103515626,
+            "height": 125.0
         }
     },
     "m_Slots": [
@@ -905,10 +1052,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -874.0,
-            "y": 85.0,
-            "width": 104.0,
-            "height": 34.0
+            "x": -1019.0,
+            "y": 84.99994659423828,
+            "width": 103.5,
+            "height": 34.000022888183597
         }
     },
     "m_Slots": [
@@ -940,10 +1087,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -729.0,
-            "y": 57.00001907348633,
+            "x": -873.9999389648438,
+            "y": 56.9999885559082,
             "width": 290.0,
-            "height": 117.99995422363281
+            "height": 117.99996948242188
         }
     },
     "m_Slots": [
@@ -988,9 +1135,9 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -67.0,
-            "y": -455.0,
-            "width": 290.0,
+            "x": -80.99999237060547,
+            "y": -761.4999389648438,
+            "width": 290.0000305175781,
             "height": 118.0
         }
     },
@@ -1184,6 +1331,30 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "3c30dc982ca74722beb02471a2522191",
+    "m_Id": 2,
+    "m_DisplayName": "Off",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Off",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "40375ee59cfc47f7abdc55e25bc9e2d7",
     "m_Id": 2,
     "m_DisplayName": "False",
@@ -1265,6 +1436,30 @@
     "m_Value": 0.5,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "4371a1dd8fdb4c52abeeafa40f989388",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {
@@ -1368,6 +1563,62 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.KeywordNode",
+    "m_ObjectId": "580e41aae5fd4e6793cd43b2fad1ac61",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "MaterialX",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 326.4999694824219,
+            "y": -702.5000610351563,
+            "width": 138.5001220703125,
+            "height": 117.99993896484375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "f205da333b1a4a86846033d9b4b0b0e6"
+        },
+        {
+            "m_Id": "83f70a85463e43d5a8feb0756a5ca165"
+        },
+        {
+            "m_Id": "3c30dc982ca74722beb02471a2522191"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Keyword": {
+        "m_Id": "1d79aad20de94e19b191d087f66ad3a4"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "58f930bd54e140dca88810ad7729a012",
+    "m_Id": 1,
+    "m_DisplayName": "X",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "X",
+    "m_StageCapability": 3,
+    "m_Value": 1.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "5bfc323d88eb40faad9e6714526b2429",
     "m_Id": 1,
@@ -1375,6 +1626,30 @@
     "m_SlotType": 0,
     "m_Hidden": false,
     "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "6190572d835b4f06a96a1891f5521b30",
+    "m_Id": 1,
+    "m_DisplayName": "On",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "On",
     "m_StageCapability": 3,
     "m_Value": {
         "x": 0.0,
@@ -1413,6 +1688,23 @@
         "w": 0.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "65c9f532898a496da96d3fdfd1018bdb",
+    "m_Id": 2,
+    "m_DisplayName": "Y",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Y",
+    "m_StageCapability": 3,
+    "m_Value": 1.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [
+        "Y"
+    ]
 }
 
 {
@@ -1629,6 +1921,78 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "798d41923a124230822d5291cf256206",
+    "m_Id": 3,
+    "m_DisplayName": "Z",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Z",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [
+        "Z"
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4Node",
+    "m_ObjectId": "7b7b83eb4b5e43649c1c0e8735d3ccf0",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Vector 4",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -369.9999084472656,
+            "y": -643.4999389648438,
+            "width": 130.99993896484376,
+            "height": 149.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "58f930bd54e140dca88810ad7729a012"
+        },
+        {
+            "m_Id": "65c9f532898a496da96d3fdfd1018bdb"
+        },
+        {
+            "m_Id": "798d41923a124230822d5291cf256206"
+        },
+        {
+            "m_Id": "1ec7191752204f0ba54cbb5611c2e9b0"
+        },
+        {
+            "m_Id": "d86bbe9ed01840fb9d8c6c844b6024a1"
+        }
+    ],
+    "synonyms": [
+        "4",
+        "v4",
+        "vec4",
+        "float4"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "7cb54dec1a8f4802ac1240d4e98bacc8",
     "m_Id": 0,
@@ -1687,6 +2051,30 @@
     "m_RangeValues": {
         "x": 0.0,
         "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "83f70a85463e43d5a8feb0756a5ca165",
+    "m_Id": 1,
+    "m_DisplayName": "On",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "On",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 
@@ -1852,10 +2240,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -899.0,
-            "y": 139.0,
-            "width": 129.0,
-            "height": 34.0
+            "x": -1044.0,
+            "y": 138.99998474121095,
+            "width": 129.00006103515626,
+            "height": 33.999969482421878
         }
     },
     "m_Slots": [
@@ -1887,10 +2275,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 259.0,
-            "y": -303.0,
-            "width": 130.0,
-            "height": 118.0
+            "x": 495.0,
+            "y": -541.5000610351563,
+            "width": 129.5,
+            "height": 118.00003051757813
         }
     },
     "m_Slots": [
@@ -1976,6 +2364,47 @@
     "m_ShaderOutputName": "Out",
     "m_StageCapability": 3,
     "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.KeywordNode",
+    "m_ObjectId": "b0b94af219dc47c38aee9594196909ff",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "MaterialX",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -541.9999389648438,
+            "y": 126.9999771118164,
+            "width": 138.49990844726563,
+            "height": 117.99996185302735
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "4371a1dd8fdb4c52abeeafa40f989388"
+        },
+        {
+            "m_Id": "6190572d835b4f06a96a1891f5521b30"
+        },
+        {
+            "m_Id": "1c3a35fc49d048f28b5744c3a19eca4b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Keyword": {
+        "m_Id": "1d79aad20de94e19b191d087f66ad3a4"
+    }
 }
 
 {
@@ -2240,10 +2669,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -207.82611083984376,
-            "y": -459.1304626464844,
-            "width": 0.0,
-            "height": 0.0
+            "x": -314.5,
+            "y": -842.5,
+            "width": 103.5,
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -2573,6 +3002,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "d86bbe9ed01840fb9d8c6c844b6024a1",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "d8e3e5bc2fa44c75bcc758e7bbd87af4",
     "m_Id": 1,
@@ -2598,10 +3052,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 504.00006103515627,
-            "y": -274.0000305175781,
-            "width": 194.00006103515626,
-            "height": 118.00003051757813
+            "x": 672.5,
+            "y": -553.5000610351563,
+            "width": 194.0001220703125,
+            "height": 117.99996948242188
         }
     },
     "m_Slots": [
@@ -2684,6 +3138,9 @@
         },
         {
             "m_Id": "b23804a2765f4d44bf943d308aa82893"
+        },
+        {
+            "m_Id": "1d79aad20de94e19b191d087f66ad3a4"
         }
     ]
 }
@@ -2907,6 +3364,30 @@
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "f205da333b1a4a86846033d9b4b0b0e6",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 


### PR DESCRIPTION
This PR adds support for conversion of the UnityGLTF/PBRGraph and UnityGLTF/UnlitGraph shaders to MaterialX through Unity's PolySpatial module. This allows building glTF-powered volumetric applications for VisionOS.

<img width="854" alt="image" src="https://github.com/KhronosGroup/UnityGLTF/assets/2693840/827070bf-ba31-4a6d-94e3-993371c41557">

Due to a bug in PolySpatial (reported as IN-72885, related to HDR color properties), emission colors and emission textures currently aren't converted correctly.