### PR TITLE
Fixed shared SkinnedMesh on export

### DIFF
--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -1097,10 +1097,7 @@ namespace UnityGLTF
 						var smr = uniquePrimitives[0].SkinnedMeshRenderer;
 						// Only export the blendShapeWeights into the Node, when it's not the first SkinnedMeshRenderer with the same Mesh
 						// Because the weights already exported into the GltfMesh
-						if (smr 
-						    && meshObj
-					        && _meshToBlendShapeAccessors.TryGetValue(meshObj, out var data)
-					        && smr != data.firstSkinnedMeshRenderer)
+						if (smr && meshObj && _meshToBlendShapeAccessors.TryGetValue(meshObj, out var data) && smr != data.firstSkinnedMeshRenderer)
 						{
 							var blendShapeWeights = GetBlendShapeWeights(smr, meshObj);
 							if (blendShapeWeights != null)
@@ -1119,7 +1116,6 @@ namespace UnityGLTF
 						}
 					}
 				}
-				
 			}
 
 			exportNodeMarker.End();

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -449,7 +449,6 @@ namespace UnityGLTF
 			{
 				if (!Equals(Mesh, other.Mesh)) return false;
 				if (Materials == null && other.Materials == null) return true;
-				if (!Equals(SkinnedMeshRenderer, other.SkinnedMeshRenderer)) return false;
 				if (!(Materials != null && other.Materials != null)) return false;
 				if (!Equals(Materials.Length, other.Materials.Length)) return false;
 				for (var i = 0; i < Materials.Length; i++)
@@ -470,10 +469,6 @@ namespace UnityGLTF
 				unchecked
 				{
 					var code = (Mesh != null ? Mesh.GetHashCode() : 0) * 397;
-					if (SkinnedMeshRenderer != null)
-					{
-						code = code ^ SkinnedMeshRenderer.GetHashCode() * 397;
-					}
 					if (Materials != null)
 					{
 						code = code ^ Materials.Length.GetHashCode() * 397;

--- a/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
@@ -17,7 +17,7 @@ namespace UnityGLTF
 	{
 		private struct MeshAccessors
 		{
-			public AccessorId aPosition, aNormal, aTangent, aTexcoord0, aTexcoord1, aColor0;
+			public AccessorId aPosition, aNormal, aTangent, aTexcoord0, aTexcoord1, aColor0, aJoints0, aWeights0;
 			public Dictionary<int, MeshPrimitive> subMeshPrimitives;
 		}
 

--- a/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
@@ -26,10 +26,12 @@ namespace UnityGLTF
 			public List<Dictionary<string, AccessorId>> targets;
 			public List<Double> weights;
 			public List<string> targetNames;
+			internal SkinnedMeshRenderer firstSkinnedMeshRenderer; 
 		}
 
 		private readonly Dictionary<Mesh, MeshAccessors> _meshToPrims = new Dictionary<Mesh, MeshAccessors>();
 		private readonly Dictionary<Mesh, BlendShapeAccessors> _meshToBlendShapeAccessors = new Dictionary<Mesh, BlendShapeAccessors>();
+		private readonly Dictionary<SkinnedMeshRenderer, List<double>> _NodeBlendShapeWeights = new Dictionary<SkinnedMeshRenderer, List<double>>();
 
 		public void RegisterPrimitivesWithNode(Node node, List<UniquePrimitive> uniquePrimitives)
 		{
@@ -362,6 +364,32 @@ namespace UnityGLTF
             return prims;
 		}
 
+		private List<double> GetBlendShapeWeights(SkinnedMeshRenderer smr, Mesh meshObj)
+		{
+			if (_NodeBlendShapeWeights.TryGetValue(smr, out var w))
+				return w;
+
+			List<Double> weights = new List<double>(meshObj.blendShapeCount);
+			
+			for (int blendShapeIndex = 0; blendShapeIndex < meshObj.blendShapeCount; blendShapeIndex++)
+			{
+				// We need to get the weight from the SkinnedMeshRenderer because this represents the currently
+				// defined weight by the user to apply to this blend shape.  If we instead got the value from
+				// the unityMesh, it would be a _per frame_ weight, and for a single-frame blend shape, that would
+				// always be 100.  A blend shape might have more than one frame if a user wanted to more tightly
+				// control how a blend shape will be animated during weight changes (e.g. maybe they want changes
+				// between 0-50% to be really minor, but between 50-100 to be extreme, hence they'd have two frames
+				// where the first frame would have a weight of 50 (meaning any weight between 0-50 should be relative
+				// to the values in this frame) and then any weight between 50-100 would be relevant to the weights in
+				// the second frame.  See Post 20 for more info:
+				// https://forum.unity3d.com/threads/is-there-some-method-to-add-blendshape-in-editor.298002/#post-2015679
+				var frameWeight = meshObj.GetBlendShapeFrameWeight(blendShapeIndex, 0);
+				weights.Add(smr.GetBlendShapeWeight(blendShapeIndex) / frameWeight);
+			}
+
+			return weights;
+		}
+		
 		// Blend Shapes / Morph Targets
 		// Adopted from Gary Hsu (bghgary)
 		// https://github.com/bghgary/glTF-Tools-for-Unity/blob/master/UnityProject/Assets/Gltf/Editor/Exporter.cs
@@ -381,7 +409,7 @@ namespace UnityGLTF
 			if (smr != null && meshObj.blendShapeCount > 0)
 			{
 				List<Dictionary<string, AccessorId>> targets = new List<Dictionary<string, AccessorId>>(meshObj.blendShapeCount);
-				List<Double> weights = new List<double>(meshObj.blendShapeCount);
+				List<Double> weights;
 				List<string> targetNames = new List<string>(meshObj.blendShapeCount);
 
 #if UNITY_2019_3_OR_NEWER
@@ -455,30 +483,19 @@ namespace UnityGLTF
 							exportTargets.Add(SemanticProperties.TANGENT, ExportSparseAccessor(null, null, SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(deltaTangents, SchemaExtensions.CoordinateSpaceConversionScale)));
 						}
 					}
+
 					targets.Add(exportTargets);
-
-					// We need to get the weight from the SkinnedMeshRenderer because this represents the currently
-					// defined weight by the user to apply to this blend shape.  If we instead got the value from
-					// the unityMesh, it would be a _per frame_ weight, and for a single-frame blend shape, that would
-					// always be 100.  A blend shape might have more than one frame if a user wanted to more tightly
-					// control how a blend shape will be animated during weight changes (e.g. maybe they want changes
-					// between 0-50% to be really minor, but between 50-100 to be extreme, hence they'd have two frames
-					// where the first frame would have a weight of 50 (meaning any weight between 0-50 should be relative
-					// to the values in this frame) and then any weight between 50-100 would be relevant to the weights in
-					// the second frame.  See Post 20 for more info:
-					// https://forum.unity3d.com/threads/is-there-some-method-to-add-blendshape-in-editor.298002/#post-2015679
-					var frameWeight = meshObj.GetBlendShapeFrameWeight(blendShapeIndex, 0);
-					if(exportTargets.Any())
-						weights.Add(smr.GetBlendShapeWeight(blendShapeIndex) / frameWeight);
-
+					
 					exportBlendShapeMarker.End();
 				}
 
+				weights = GetBlendShapeWeights(smr, meshObj);
 				if(weights.Any() && targets.Any())
 				{
 					mesh.Weights = weights;
 					mesh.TargetNames = targetNames;
 					primitive.Targets = targets;
+					_NodeBlendShapeWeights.Add(smr, weights);
 				}
 				else
 				{
@@ -492,7 +509,8 @@ namespace UnityGLTF
 				{
 					targets = targets,
 					weights = weights,
-					targetNames = targetNames
+					targetNames = targetNames,
+					firstSkinnedMeshRenderer = smr
 				});
 			}
 		}

--- a/Runtime/Scripts/SceneExporter/ExporterSkinning.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterSkinning.cs
@@ -89,6 +89,12 @@ namespace UnityGLTF
 				GLTF.Schema.GLTFMesh gltfMesh = _root.Meshes[val.Id];
 				if(gltfMesh != null)
 				{
+					var accessors = _meshToPrims[mesh];
+					if (accessors.aJoints0 != null)
+						sharedBones = accessors.aJoints0;
+					if (accessors.aWeights0 != null)
+						sharedWeights = accessors.aWeights0;
+					
 					foreach (MeshPrimitive prim in gltfMesh.Primitives)
 					{
 						if (!prim.Attributes.ContainsKey("JOINTS_0"))
@@ -101,6 +107,8 @@ namespace UnityGLTF
 								jointsAccessor.Value.BufferView.Value.Target = BufferViewTarget.ArrayBuffer;
 								prim.Attributes.Add("JOINTS_0", jointsAccessor);
 								sharedBones = jointsAccessor;
+								accessors.aJoints0 = jointsAccessor;
+								_meshToPrims[mesh] = accessors;
 							}
 						}
 
@@ -114,6 +122,8 @@ namespace UnityGLTF
 								weightsAccessor.Value.BufferView.Value.Target = BufferViewTarget.ArrayBuffer;
 								prim.Attributes.Add("WEIGHTS_0", weightsAccessor);
 								sharedWeights = weightsAccessor;
+								accessors.aWeights0 = weightsAccessor;
+								_meshToPrims[mesh] = accessors;
 							}
 						}
 					}


### PR DESCRIPTION
When a SkinnedMesh was used by multiple Nodes, the SkinnedMesh was exported for each Node. Only some attribute accessors was shared between them. Which brokes the instancing capaility.

Now, it will only export the SkinnedMesh once. To keep the support for different blendshape weights settings per node, the weigths gets also written into the node weights property (only when they differs from the first/default weights).

The sample file contains two versions:
- "Different Weights":  Each skinnedMesh Node uses different blendshape weights
- "OnlyDefaultWeights": Each skinnedMesh Node shares the same blendshape weights

Sample Files:
[AnimatedMorphCubes.zip](https://github.com/KhronosGroup/UnityGLTF/files/14885649/AnimatedMorphCubes.zip)
