### PR TITLE
Avoid unnecessary texture duplication on import  - fixed #713

### DIFF
--- a/Runtime/Scripts/SceneImporter/ImporterTextures.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterTextures.cs
@@ -184,7 +184,7 @@ namespace UnityGLTF
 				texture.wrapMode = TextureWrapMode.Repeat;
 				texture.wrapModeV = TextureWrapMode.Repeat;
 				texture.wrapModeU = TextureWrapMode.Repeat;
-				texture.filterMode = FilterMode.Trilinear;
+				texture.filterMode = FilterMode.Bilinear;
 			}
 
 			await Task.CompletedTask;
@@ -448,7 +448,7 @@ namespace UnityGLTF
 							break;
 						default:
 							Debug.Log(LogType.Warning, "Unsupported Sampler.MinFilter: " + sampler.MinFilter+ $" (File: {_gltfFileName})");
-							desiredFilterMode = FilterMode.Trilinear;
+							desiredFilterMode = FilterMode.Bilinear;
 							break;
 					}
 
@@ -473,7 +473,7 @@ namespace UnityGLTF
 				}
 				else
 				{
-					desiredFilterMode = FilterMode.Trilinear;
+					desiredFilterMode = FilterMode.Bilinear;
 					desiredWrapModeS = TextureWrapMode.Repeat;
 					desiredWrapModeT = TextureWrapMode.Repeat;
 				}

--- a/Runtime/Scripts/SceneImporter/ImporterTextures.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterTextures.cs
@@ -184,7 +184,7 @@ namespace UnityGLTF
 				texture.wrapMode = TextureWrapMode.Repeat;
 				texture.wrapModeV = TextureWrapMode.Repeat;
 				texture.wrapModeU = TextureWrapMode.Repeat;
-				texture.filterMode = FilterMode.Bilinear;
+				texture.filterMode = FilterMode.Trilinear;
 			}
 
 			await Task.CompletedTask;
@@ -418,6 +418,9 @@ namespace UnityGLTF
 			{
 				int sourceId = GetTextureSourceId(texture);
 				GLTFImage image = _gltfRoot.Images[sourceId];
+				
+				bool isFirstInstance = _assetCache.ImageCache[sourceId] == null;
+				
 				await ConstructImage(image, sourceId, markGpuOnly, isLinear, isNormal);
 
 				var source = _assetCache.ImageCache[sourceId];
@@ -473,6 +476,13 @@ namespace UnityGLTF
 					desiredFilterMode = FilterMode.Trilinear;
 					desiredWrapModeS = TextureWrapMode.Repeat;
 					desiredWrapModeT = TextureWrapMode.Repeat;
+				}
+
+				if (isFirstInstance)
+				{
+					source.filterMode = desiredFilterMode;
+					source.wrapModeU = desiredWrapModeS;
+					source.wrapModeV = desiredWrapModeT;		
 				}
 
 				var matchSamplerState = source.filterMode == desiredFilterMode && source.wrapModeU == desiredWrapModeS && source.wrapModeV == desiredWrapModeT;


### PR DESCRIPTION
Before: Imported textures had the possibility that they are created twice in memory, because the loaded image was using the default sample settings, not the settings from the first texture that referenced to the same image. So the "matchSamplerState" can't be true here, even when the image was using by only one texture.
After: Now it will use the texture sample setting of the first texture and set it to the loaded image. 

[Sample.zip](https://github.com/KhronosGroup/UnityGLTF/files/14914878/Sample.zip)
