### PR TITLE
Removed error logs for Texture and Node count on import

### DIFF
--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -508,7 +508,6 @@ namespace UnityGLTF
 			}
 			_gltfStream.Stream.Close();
 			DisposeNativeBuffers();
-			if (progressStatus.TextureLoaded > progressStatus.TextureTotal) Debug.Log(LogType.Error, $"Textures loaded ({progressStatus.TextureLoaded}) is larger than texture total in the scene ({progressStatus.TextureTotal}) (File: {_gltfFileName})");
 
 			onLoadComplete?.Invoke(LastLoadedScene, null);
 		}

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -508,7 +508,6 @@ namespace UnityGLTF
 			}
 			_gltfStream.Stream.Close();
 			DisposeNativeBuffers();
-			if (progressStatus.NodeLoaded != progressStatus.NodeTotal) Debug.Log(LogType.Error, $"Nodes loaded ({progressStatus.NodeLoaded}) does not match node total in the scene ({progressStatus.NodeTotal}) (File: {_gltfFileName})");
 			if (progressStatus.TextureLoaded > progressStatus.TextureTotal) Debug.Log(LogType.Error, $"Textures loaded ({progressStatus.TextureLoaded}) is larger than texture total in the scene ({progressStatus.TextureTotal}) (File: {_gltfFileName})");
 
 			onLoadComplete?.Invoke(LastLoadedScene, null);


### PR DESCRIPTION
These error logs are not correct.
The Node Count can be higher on import in some cases. Like when using LODs or with Camera/Lights which will be resulted in added 180° flipped rotation correcting gameobjects.
The texture count can also be higher when one texture is used with multiple samplers. We need to duplicate these texture in unity for different sampler settings.