### PR TITLE
Fix min/max mismatch errors from ExportSparseAccessor

### DIFF
--- a/Runtime/Scripts/SceneExporter/ExporterAccessors.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterAccessors.cs
@@ -254,10 +254,10 @@ public partial class GLTFSceneExporter
 #else
 			foreach (var vec in arr)
 			{
-				_bufferWriter.Write(vect.x);
-				_bufferWriter.Write(vect.y);
-				_bufferWriter.Write(vect.z);
-				_bufferWriter.Write(vect.w);
+				_bufferWriter.Write(vec.x);
+				_bufferWriter.Write(vec.y);
+				_bufferWriter.Write(vec.z);
+				_bufferWriter.Write(vec.w);
 			}
 #endif
 			exportAccessorBufferWriteMarker.End();

--- a/Runtime/Scripts/SceneExporter/ExporterAccessors.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterAccessors.cs
@@ -842,7 +842,7 @@ public partial class GLTFSceneExporter
 			for (int i = 0; i < arr.Length; i++)
 			{
 				var comparer = (baseAccessor == null || baseData == null) ? Vector3.zero : baseData[i];
-				if (comparer != arr[i])
+				if (!comparer.Equals(arr[i]))
 				{
 					indices.Add(i);
 				}


### PR DESCRIPTION
When exporting sparse accessors through the ExportAccessors class, UnityGLTF currently uses the == operator to compare between `baseData` and `data`. However, this operator determines approximate equality rather than exact equality, causing some data values to be considered identical to the base value (usually a zero vector) and thus omitted.

Although this difference might seem negligible, it can result in discrepancies between the values referenced for min/max calculations and those stored in the buffer, potentially causing errors like `ACCESSOR_MIN_MISMATCH`. To address this issue, I have replaced the == operator with the `Equals` method to perform precise comparisons.