### PR TITLE
fixed TMPro export with multiple font weights (invalid texture hash)

### DIFF
--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -429,7 +429,9 @@ namespace UnityGLTF
 				{
 					// We dont want to use GetHashCode() for the texture here since it will change the hash after restarting the editor
 					#if UNITY_EDITOR
-					var hashCode = Texture ? Texture.imageContentsHash.GetHashCode() : 0;
+					var hashCode = 0;
+					if (Texture != null) 
+						hashCode = Texture.imageContentsHash.isValid ? Texture.imageContentsHash.GetHashCode() : Texture.GetHashCode();
 					#else
 					var hashCode = Texture ? Texture.GetHashCode() : 0;
 					#endif


### PR DESCRIPTION
I had trouble exporting objects with TMPro text, containing multiple font weights (bold, italic etc.)
The UnityGLTF correctly exports all font atlas materials, but their textures are all the same.
After closer inspection, it seems that these textures do not have a valid `Texture.imageContentsHash`, which leads to exporter to just re-use the previously cached atlas texture, even if they are different.
I made it so in case of `!Texture.imageContentsHash.isValid`, the `UniqueTexture.GetHashCode()` fallbacks to using `Texture.GetHashCode()`.

Example:
![fix_demo](https://github.com/KhronosGroup/UnityGLTF/assets/49528659/0ca90aef-6553-40ec-8610-3b9b5eebd2eb)

