### PR TITLE
fixes #740 - Added missing ExtTransform support for some textures in AnimationPointer

### DIFF
--- a/Runtime/Plugins/GLTFSerialization/Schema/AnimationPointerData.cs
+++ b/Runtime/Plugins/GLTFSerialization/Schema/AnimationPointerData.cs
@@ -12,9 +12,12 @@ namespace GLTF.Schema
         public ImportValuesConversion importAccessorContentConversion;
 
         public string primaryPath = "";
+        public string primaryProperty = "";
+        
         public AttributeAccessor primaryData;
         
         public string secondaryPath = "";
+        public string secondaryProperty = "";
         public AttributeAccessor secondaryData;
     }
 

--- a/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
@@ -384,16 +384,26 @@ namespace UnityGLTF
 									if (!mat.UnityMaterial)
 										continue;
 									
-									if (!AnimationPointerHelpers.BuildImportMaterialAnimationPointerData(pointerImportContext.materialPropertiesRemapper, mat.UnityMaterial, gltfPropertyPath, samplerCache.Output.AccessorId.Value.Type, out pointerData))
+									if (!AnimationPointerHelpers.BuildImportMaterialAnimationPointerData(pointer.path, pointerImportContext.materialPropertiesRemapper, mat.UnityMaterial, gltfPropertyPath, samplerCache.Output, out pointerData))
 										continue;
-									
-									pointerData.primaryData = samplerCache.Output;
-									pointerData.primaryPath = pointer.path;
-									if (!string.IsNullOrEmpty(pointerData.secondaryPath))
+									pointerData.targetNodeIds = nodeIds;
+									if (string.IsNullOrEmpty(pointerData.primaryPath))
+									{
+										pointerData.primaryPath = "/" + pointerHierarchy.ExtractPath().Replace(rootIndex.next.ExtractPath(), pointerData.primaryProperty);
+										pointerData.primaryData = FindSecondaryChannel(pointerData.primaryPath);
+										if (pointerData.primaryData != null)
+										{
+											//cancel here and process this combined property later when we found first the Primary Property
+											continue;
+										}
+									}
+									else
+									if (!string.IsNullOrEmpty(pointerData.secondaryProperty))
 									{
 										// When an property has potentially a second Sampler, we need to find it. e.g. like EmissionFactor and EmissionStrength
-										string secondaryPath = $"/{pointerHierarchy.elementName}/{rootIndex.index.ToString()}/{pointerData.secondaryPath}";
-										pointerData.secondaryData = FindSecondaryChannel(secondaryPath);
+
+										pointerData.secondaryPath = "/" + pointerHierarchy.ExtractPath().Replace(rootIndex.next.ExtractPath(), pointerData.secondaryProperty);
+										pointerData.secondaryData = FindSecondaryChannel(pointerData.secondaryPath);
 									}
 									break;
 								case "cameras":


### PR DESCRIPTION
- Added more ExtTransform support for Textures when using AnimationPointers
- Fixed an issue when only offset is used with ExtTransform in AnimationPointers
- some changes on MaterialRemapper for easier adding support of ExtTransform 

[samples.zip](https://github.com/user-attachments/files/16157222/samples.zip)
