### PR TITLE
Flipped CameraOpqaueTexture fix on WebGl/OpenGl/...

### DIFF
--- a/Runtime/Shaders/ShaderGraph/PBRHelpers.cginc
+++ b/Runtime/Shaders/ShaderGraph/PBRHelpers.cginc
@@ -51,6 +51,11 @@ float3 Sample4Tap(float2 uv, float lod)
 
 void SampleSceneColor_float(float2 uv, float lod, out float3 color)
 {
+	#if !UNITY_UV_STARTS_AT_TOP
+	if (_CameraOpaqueTexture_TexelSize.y > 0)
+		uv.y = 1-uv.y;
+	#endif
+	
 	#define REQUIRE_OPAQUE_TEXTURE // seems we need to define this ourselves? HDSceneColorNode does that as well
 
 #if defined(USE_CAMERA_OPAQUE)


### PR DESCRIPTION
Added UNITY_UV_STARTS_AT_TOP check in SampleSceneColor to corrent flipped uv.y coordinate on CameraOpqaueTexture for WebGl/OpenGl based render APIs.
Based on Unity Documentation  

This fixes the issue #746