### PR TITLE
Bonemapping fix for already correct bone names on import

### DIFF
--- a/Editor/Scripts/Internal/AvatarUtils.cs
+++ b/Editor/Scripts/Internal/AvatarUtils.cs
@@ -227,19 +227,23 @@ namespace UnityGLTF
 			Transform[] avatarTransforms = avatarRoot.GetComponentsInChildren<Transform>();
 			foreach (Transform avatarTransform in avatarTransforms)
 			{
-				if (HumanSkeletonNames.TryGetValue(avatarTransform.name, out string humanName))
+				string humanName = avatarTransform.name;
+				if (HumanSkeletonNames.TryGetValue(humanName, out string newHumanName))
+					humanName = newHumanName;
+				else
+					if (!HumanSkeletonNames.ContainsValue(humanName))
+						continue;
+			
+				HumanBone bone = new HumanBone
 				{
-					HumanBone bone = new HumanBone
-					{
-						boneName = avatarTransform.name,
-						humanName = humanName,
-						limit = new HumanLimit()
-					};
-					bone.limit.useDefaultValues = true;
+					boneName = avatarTransform.name,
+					humanName = humanName,
+					limit = new HumanLimit()
+				};
+				bone.limit.useDefaultValues = true;
 
-					human.Add(bone);
-				}
-			}
+				human.Add(bone);
+			} 
 			return human.ToArray();
 		}
 	}


### PR DESCRIPTION
Before:  On importing a humanoid avatar with correct bone names, these bones are ignored when creating an avatar. 
After: When the bone names are already correct and not required to convert them, they will also be added.  To check if the name is correct, it now also check if the imported bone name exists as a value from the bone dictionary.

This fixes the issue #751.
