### PR TITLE
Added missing AnimationCacheData to RefCountedCacheData Script

### DIFF
--- a/Runtime/Scripts/Cache/RefCountedCacheData.cs
+++ b/Runtime/Scripts/Cache/RefCountedCacheData.cs
@@ -36,18 +36,24 @@ namespace UnityGLTF.Cache
 		/// Textures used by this GLTF node.
 		/// </summary>
 		public TextureCacheData[] TextureCache { get; private set; }
-
+		
+		/// <summary>
+		/// Animations used by this GLTF node.
+		/// </summary>
+		public AnimationCacheData[] AnimationCache { get; private set; }
+		
 		/// <summary>
 		/// Textures from the AssetCache that might need to be cleaned up
 		/// </summary>
 		public Texture2D[] ImageCache { get; private set; }
 
-		public RefCountedCacheData(MaterialCacheData[] materialCache, MeshCacheData[] meshCache, TextureCacheData[] textureCache, Texture2D[] imageCache)
+		public RefCountedCacheData(MaterialCacheData[] materialCache, MeshCacheData[] meshCache, TextureCacheData[] textureCache, Texture2D[] imageCache, AnimationCacheData[] animationCache)
 		{
 			MaterialCache = materialCache;
 			MeshCache = meshCache;
 			TextureCache = textureCache;
 			ImageCache = imageCache;
+			AnimationCache = animationCache;
 		}
 
 		public void IncreaseRefCount()
@@ -116,6 +122,16 @@ namespace UnityGLTF.Cache
 				{
 					UnityEngine.Object.Destroy(ImageCache[i]);
 					ImageCache[i] = null;
+				}
+			}
+			
+			// Destroy the cached animations
+			for (int i = 0; i < AnimationCache.Length; i++)
+			{
+				if (AnimationCache[i] != null)
+				{
+					UnityEngine.Object.Destroy(AnimationCache[i].LoadedAnimationClip);
+					AnimationCache[i] = null;
 				}
 			}
 

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -654,7 +654,8 @@ namespace UnityGLTF
 				_assetCache.MaterialCache,
 				_assetCache.MeshCache,
 				_assetCache.TextureCache,
-				_assetCache.ImageCache
+				_assetCache.ImageCache,
+				_assetCache.AnimationCache
 			);
 		}
 


### PR DESCRIPTION
In case of runtime loading of Glb/Gltfs, the animation clips wasn't destroyed by the RefCountedCachaData script when it gets destroyed. Which can be resulted in unused Anim.Clips in memory.