### PR TITLE
Made ShaderOverride public on GLTFComponent

### DIFF
--- a/Runtime/Scripts/GLTFComponent.cs
+++ b/Runtime/Scripts/GLTFComponent.cs
@@ -48,6 +48,16 @@ namespace UnityGLTF
 
 		[SerializeField]
 		private Shader shaderOverride = null;
+		
+		public Shader ShaderOverride
+		{
+			get => shaderOverride;
+			set
+			{
+				shaderOverride = value;
+				ApplyOverrideShader();
+			}
+		}
 
 		[Header("Import Settings")]
 		public GLTFImporterNormals ImportNormals = GLTFImporterNormals.Import;
@@ -130,14 +140,7 @@ namespace UnityGLTF
 				);
 
 				// Override the shaders on all materials if a shader is provided
-				if (shaderOverride != null)
-				{
-					Renderer[] renderers = gameObject.GetComponentsInChildren<Renderer>();
-					foreach (Renderer renderer in renderers)
-					{
-						renderer.sharedMaterial.shader = shaderOverride;
-					}
-				}
+				ApplyOverrideShader();
 
 				LastLoadedScene = sceneImporter.LastLoadedScene;
 				
@@ -160,6 +163,18 @@ namespace UnityGLTF
 					sceneImporter?.Dispose();
 					sceneImporter = null;
 					importOptions.DataLoader = null;
+				}
+			}
+		}
+		
+		public void ApplyOverrideShader()
+		{
+			if (shaderOverride != null)
+			{
+				Renderer[] renderers = gameObject.GetComponentsInChildren<Renderer>();
+				foreach (Renderer renderer in renderers)
+				{
+					renderer.sharedMaterial.shader = shaderOverride;
 				}
 			}
 		}


### PR DESCRIPTION
For accessing the ShaderOverride property on GLTFComponent via script, i added a public property for it.  Can also be changed after a gltf is loaded.

fixes #754 "how to access shaderoverride"