### PR TITLE
Feature: Resource Deduplication on import

### DIFF
--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -86,6 +86,8 @@ namespace UnityGLTF
 	    [Tooltip("Turn this off to create an explicit GameObject for the glTF scene. A scene root will always be created if there's more than one root node.")]
         [SerializeField] internal bool _removeEmptyRootObjects = true;
         [SerializeField] internal float _scaleFactor = 1.0f;
+		[Tooltip("Reduces identical resources. e.g. when identical meshes are found, only one will be imported.")]
+        [SerializeField] internal bool _deduplicateResources = false;
         [SerializeField] internal int _maximumLod = 300;
         [SerializeField] internal bool _readWriteEnabled = true;
         [SerializeField] internal bool _generateColliders = false;
@@ -915,6 +917,7 @@ namespace UnityGLTF
 			    ImportBlendShapeNames = _importBlendShapeNames,
 			    BlendShapeFrameWeight = _blendShapeFrameWeight,
 			    CameraImport = _importCamera,
+			    DeduplicateResources = _deduplicateResources,
 		    };
 
 		    using (var stream = File.OpenRead(projectFilePath))

--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -85,9 +85,9 @@ namespace UnityGLTF
 
 	    [Tooltip("Turn this off to create an explicit GameObject for the glTF scene. A scene root will always be created if there's more than one root node.")]
         [SerializeField] internal bool _removeEmptyRootObjects = true;
-        [SerializeField] internal float _scaleFactor = 1.0f;
-		[Tooltip("Reduces identical resources. e.g. when identical meshes are found, only one will be imported.")]
-        [SerializeField] internal bool _deduplicateResources = false;
+        [SerializeField] internal float _scaleFactor = 1.0f; 
+        [Tooltip("Reduces identical resources. e.g. when identical meshes are found, only one will be imported.")]
+        [SerializeField] internal DeduplicateOptions _deduplicateResources = DeduplicateOptions.None;
         [SerializeField] internal int _maximumLod = 300;
         [SerializeField] internal bool _readWriteEnabled = true;
         [SerializeField] internal bool _generateColliders = false;

--- a/Editor/Scripts/GLTFImporterInspector.cs
+++ b/Editor/Scripts/GLTFImporterInspector.cs
@@ -81,6 +81,7 @@ namespace UnityGLTF
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._removeEmptyRootObjects)));
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._scaleFactor)));
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._importCamera)));
+			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._deduplicateResources)));
 			// EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._maximumLod)), new GUIContent("Maximum Shader LOD"));
 			EditorGUILayout.Separator();
 			

--- a/Editor/Scripts/ShaderGraph/MaterialEditorBridge.cs
+++ b/Editor/Scripts/ShaderGraph/MaterialEditorBridge.cs
@@ -81,7 +81,7 @@ namespace UnityGLTF
 			// after importing a changed material, which can be confusing. Could be caching inside PBRGraphGUI
 			AssetDatabase.Refresh();
 
-			EditorApplication.update += () =>
+			EditorApplication.delayCall += () =>
 			{
 				// Repaint Inspector, newly imported values can be different if we're not perfectly round tripping
 				foreach (var editor in ActiveEditorTracker.sharedTracker.activeEditors)

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ If your plugin reads/writes custom extension data, you need to also implement `G
 
 ## Known Issues
 
-- Blend shapes with in-betweens are currently not supported. 
+- Blend shape in-betweens will not be exported as glTF does not have that functionality. 
 - Support for glTF files with multiple scenes is limited. 
 - Some material options (e.g. MAOS maps) are currently not exported correctly. 
 

--- a/README.md
+++ b/README.md
@@ -295,13 +295,13 @@ Animation components and their legacy clips can also be exported.
 
 ### KHR_animation_pointer support
 
-UnityGLTF supports exporting animations with the KHR_animation_pointer extension. 
+UnityGLTF supports importing and exporting animations with the KHR_animation_pointer extension. 
 The core glTF spec only allows animation node transforms and blend shape weights, while this extension allows animating arbitrary properties in the glTF file – 
 including material and object properties, even in custom extensions and script components.
 
 Exporting with KHR_animation_pointer can be turned on in `Project Settings > UnityGLTF` by enabling the KHR_animation_pointer plugin.
 
-> **Note:** The exported files can be viewed with Gestaltor, Babylon Sandbox, and Needle Engine, but currently not with three.js / model-viewer. See https://github.com/mrdoob/three.js/pull/24108. They can also not be reimported into UnityGLTF at this point.
+> **Note:** The exported files can be viewed with Gestaltor, Babylon Sandbox, and Needle Engine, but currently not with three.js / model-viewer. See https://github.com/mrdoob/three.js/pull/24108.
 
 ## Blend Shape Export
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,6 @@ If your plugin reads/writes custom extension data, you need to also implement `G
 
 - Blend shape in-betweens will not be exported as glTF does not have that functionality. 
 - Support for glTF files with multiple scenes is limited. 
-- Some material options (e.g. MAOS maps) are currently not exported correctly. 
 
 ## Contributing
 

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -15,9 +15,7 @@ using UnityGLTF.Extensions;
 using UnityGLTF.Loader;
 using UnityGLTF.Plugins;
 using Quaternion = UnityEngine.Quaternion;
-using Vector2 = UnityEngine.Vector2;
 using Vector3 = UnityEngine.Vector3;
-using Vector4 = UnityEngine.Vector4;
 #if !WINDOWS_UWP && !UNITY_WEBGL
 using ThreadPriority = System.Threading.ThreadPriority;
 #endif
@@ -81,120 +79,7 @@ namespace UnityGLTF
 		Mecanim,
 		MecanimHumanoid,
 	}
-
-	public class UnityMeshData
-	{
-		public bool[] subMeshDataCreated;
-		public Vector3[] Vertices;
-		public Vector3[] Normals;
-		public Vector4[] Tangents;
-		public Vector2[] Uv1;
-		public Vector2[] Uv2;
-		public Vector2[] Uv3;
-		public Vector2[] Uv4;
-		public Color[] Colors;
-		public BoneWeight[] BoneWeights;
-
-		public Vector3[][] MorphTargetVertices;
-		public Vector3[][] MorphTargetNormals;
-		public Vector3[][] MorphTargetTangents;
-
-		public MeshTopology[] Topology;
-		public DrawMode[] DrawModes;
-		public int[][] Indices;
-		
-		public HashSet<int> alreadyAddedAccessors = new HashSet<int>();
-		public uint[] subMeshVertexOffset;
-		
-		public void Clear()
-		{
-			Vertices = null;
-			Normals = null;
-			Tangents = null;
-			Uv1 = null;
-			Uv2 = null;
-			Uv3 = null;
-			Uv4 = null;
-			Colors = null;
-			BoneWeights = null;
-			MorphTargetVertices = null;
-			MorphTargetNormals = null;
-			MorphTargetTangents = null;
-			Topology = null;
-			Indices = null;
-			subMeshVertexOffset = null;
-		}
-
-		public bool IsEqual(UnityMeshData other)
-		{
-			bool CompareArray<T>(T[] array1, T[] array2) 
-			{
-				if (array1 == null && array2 == null)
-					return true;
-				if (array1 == array2)
-					return true;
-				if (array1?.Length != array2?.Length)
-					return false;
-				
-				for (int i = 0; i < array1.Length; i++)
-				{
-					if (!array1[i].Equals(array2[i]))
-						return false;
-				}
-
-				return true;
-			}
-			
-			bool CompareArray2<T>(T[][] array1, T[][] array2) 
-			{
-				if (array1 == null && array2 == null)
-					return true;
-				if (array1 == array2)
-					return true;
-				if (array1?.Length != array2?.Length)
-					return false;
-				
-				for (int i = 0; i < array1.Length; i++)
-				{
-					if (array1[i] == null && array2[i] == null)
-						continue;
-					if (array1[i] == array2[i])
-						continue;
-					
-					if (array1[i].Length != array2[i].Length)
-						return false;
-					
-					for (int j = 0; j < array1.Length; j++)
-					{
-						if (!array1[i][j].Equals(array2[i][j]))
-							return false;
-					}
-				}
-
-				return true;
-			}
-			
-			if (!CompareArray(Vertices, other.Vertices)
-			    || !CompareArray(Normals, other.Normals)
-			    || !CompareArray(Tangents, other.Tangents)
-			    || !CompareArray(Uv1, other.Uv1)
-			    || !CompareArray(Uv2, other.Uv2)
-			    || !CompareArray(Uv3, other.Uv3)
-			    || !CompareArray(Uv4, other.Uv4)
-			    || !CompareArray(Colors, other.Colors)
-			    || !CompareArray(BoneWeights, other.BoneWeights)
-				|| !CompareArray(Topology, other.Topology)
-				|| !CompareArray(DrawModes, other.DrawModes)
-				|| !CompareArray2(MorphTargetVertices, other.MorphTargetVertices)
-				|| !CompareArray2(MorphTargetNormals, other.MorphTargetNormals)
-				|| !CompareArray2(MorphTargetTangents, other.MorphTargetTangents)
-				|| !CompareArray2(Indices, other.Indices))
-				return false;
-			
-			return true;
-		}
-	}
-
+	
 	public struct ImportProgress
 	{
 		public bool IsDownloaded;

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -496,7 +496,9 @@ namespace UnityGLTF
 				DisposeNativeBuffers();
 
 				onLoadComplete?.Invoke(null, ExceptionDispatchInfo.Capture(ex));
-				Debug.Log(LogType.Error, $"Error loading file: {_gltfFileName}");
+				Debug.Log(LogType.Error, $"Error loading file: {_gltfFileName}" 
+				                         + System.Environment.NewLine + "Message: " + ex.Message
+				                         + System.Environment.NewLine + "StackTrace: " + ex.StackTrace);
 				throw;
 			}
 			finally

--- a/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -1361,5 +1361,47 @@ namespace UnityGLTF
 			for (var i = 0; i < x; i++) result[i] = new T[y];
 			return result;
 		}
+
+		private void CheckForMeshDuplicates()
+		{
+			Dictionary<int, int> meshDuplicates = new Dictionary<int, int>();
+
+			for (int meshIndex = 0; meshIndex < _gltfRoot.Meshes.Count; meshIndex++)
+			{
+				if (meshDuplicates.ContainsKey(meshIndex))
+				    continue;
+				
+				for (int i = meshIndex+1; i < _gltfRoot.Meshes.Count; i++)
+				{
+					
+					if (i == meshIndex)
+						continue;
+					if (_assetCache.MeshCache[i] == null)
+						continue;
+
+					if (_assetCache.UnityMeshDataCache[i] == null
+					    || _assetCache.UnityMeshDataCache[meshIndex] == null)
+						continue;
+
+					var meshIsEqual = _assetCache.UnityMeshDataCache[i]
+						.IsEqual(_assetCache.UnityMeshDataCache[meshIndex]);
+					
+					if (meshIsEqual)
+						meshDuplicates[i] = meshIndex;
+				}
+			}
+
+			foreach (var dm in meshDuplicates)
+			{
+				for (int i = 0; i < _gltfRoot.Nodes.Count; i++)
+				{
+					if (_gltfRoot.Nodes[i].Mesh != null && _gltfRoot.Nodes[i].Mesh.Id == dm.Key)
+					{
+						_gltfRoot.Nodes[i].Mesh.Id = dm.Value;
+					}
+				}
+			}
+
+		}
 	}
 }

--- a/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -1397,6 +1397,9 @@ namespace UnityGLTF
 				{
 					if (_gltfRoot.Nodes[i].Mesh != null && _gltfRoot.Nodes[i].Mesh.Id == dm.Key)
 					{
+						if (_gltfRoot.Nodes[i].Weights == null && _gltfRoot.Meshes[dm.Value].Weights != null)
+							_gltfRoot.Nodes[i].Weights = _gltfRoot.Meshes[_gltfRoot.Nodes[i].Mesh.Id].Weights;
+						
 						_gltfRoot.Nodes[i].Mesh.Id = dm.Value;
 					}
 				}

--- a/Runtime/Scripts/SceneImporter/ImporterTextures.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterTextures.cs
@@ -134,35 +134,35 @@ namespace UnityGLTF
         }
         
         private Stream GetImageStream(GLTFImage image)
-		{
+        {
 	        Stream stream = null;
-			if (image.Uri == null)
-			{
-	            if (image.BufferView == null)
-		            return null;
-	            
-	            var bufferView = image.BufferView.Value;
-	            BufferCacheData bufferContents = _assetCache.BufferCache[bufferView.Buffer.Id];
-	            if (bufferContents.bufferData.IsCreated)
-	            {
-		            bufferContents.Stream.Position = bufferView.ByteOffset + bufferContents.ChunkOffset;
-		            stream = new SubStream(bufferContents.Stream, 0, bufferView.ByteLength);
-	            }
-			}
-			else
-			{
-	            string uri = image.Uri;
+	        if (image.Uri == null)
+	        {
+		        if (image.BufferView == null)
+			        return null;
 
-	            byte[] bufferData;
-	            URIHelper.TryParseBase64(uri, out bufferData);
-	            if (bufferData != null)
-	            {
-		            stream = new MemoryStream(bufferData, 0, bufferData.Length, false, true);
-	            }
-			}
+		        var bufferView = image.BufferView.Value;
+		        BufferCacheData bufferContents = _assetCache.BufferCache[bufferView.Buffer.Id];
+		        if (bufferContents.bufferData.IsCreated)
+		        {
+			        bufferContents.Stream.Position = bufferView.ByteOffset + bufferContents.ChunkOffset;
+			        stream = new SubStream(bufferContents.Stream, 0, bufferView.ByteLength);
+		        }
+	        }
+	        else
+	        {
+		        string uri = image.Uri;
 
-			return stream;
-		}
+		        byte[] bufferData;
+		        URIHelper.TryParseBase64(uri, out bufferData);
+		        if (bufferData != null)
+		        {
+			        stream = new MemoryStream(bufferData, 0, bufferData.Length, false, true);
+		        }
+	        }
+
+	        return stream;
+        }
       
 		protected async Task ConstructImage(GLTFImage image, int imageCacheIndex, bool markGpuOnly, bool isLinear, bool isNormal)
 		{

--- a/Runtime/Scripts/SceneImporter/UnityMeshData.cs
+++ b/Runtime/Scripts/SceneImporter/UnityMeshData.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using GLTF.Schema;
+using UnityEngine;
+
+namespace UnityGLTF
+{
+    public class UnityMeshData
+    {
+        public bool[] subMeshDataCreated;
+        public Vector3[] Vertices;
+        public Vector3[] Normals;
+        public Vector4[] Tangents;
+        public Vector2[] Uv1;
+        public Vector2[] Uv2;
+        public Vector2[] Uv3;
+        public Vector2[] Uv4;
+        public Color[] Colors;
+        public BoneWeight[] BoneWeights;
+
+        public Vector3[][] MorphTargetVertices;
+        public Vector3[][] MorphTargetNormals;
+        public Vector3[][] MorphTargetTangents;
+
+        public MeshTopology[] Topology;
+        public DrawMode[] DrawModes;
+        public int[][] Indices;
+
+        public HashSet<int> alreadyAddedAccessors = new HashSet<int>();
+        public uint[] subMeshVertexOffset;
+
+        public void Clear()
+        {
+            Vertices = null;
+            Normals = null;
+            Tangents = null;
+            Uv1 = null;
+            Uv2 = null;
+            Uv3 = null;
+            Uv4 = null;
+            Colors = null;
+            BoneWeights = null;
+            MorphTargetVertices = null;
+            MorphTargetNormals = null;
+            MorphTargetTangents = null;
+            Topology = null;
+            Indices = null;
+            subMeshVertexOffset = null;
+        }
+
+        public bool IsEqual(UnityMeshData other)
+        {
+            bool CompareArray<T>(T[] array1, T[] array2)
+            {
+                if (array1 == null && array2 == null)
+                    return true;
+                if (array1 == array2)
+                    return true;
+                if (array1?.Length != array2?.Length)
+                    return false;
+
+                for (int i = 0; i < array1.Length; i++)
+                {
+                    if (!array1[i].Equals(array2[i]))
+                        return false;
+                }
+
+                return true;
+            }
+
+            bool CompareArray2<T>(T[][] array1, T[][] array2)
+            {
+                if (array1 == null && array2 == null)
+                    return true;
+                if (array1 == array2)
+                    return true;
+                if (array1?.Length != array2?.Length)
+                    return false;
+
+                for (int i = 0; i < array1.Length; i++)
+                {
+                    if (array1[i] == null && array2[i] == null)
+                        continue;
+                    if (array1[i] == array2[i])
+                        continue;
+
+                    if (array1[i].Length != array2[i].Length)
+                        return false;
+
+                    for (int j = 0; j < array1.Length; j++)
+                    {
+                        if (!array1[i][j].Equals(array2[i][j]))
+                            return false;
+                    }
+                }
+
+                return true;
+            }
+
+            if (!CompareArray(Vertices, other.Vertices)
+                || !CompareArray(Normals, other.Normals)
+                || !CompareArray(Tangents, other.Tangents)
+                || !CompareArray(Uv1, other.Uv1)
+                || !CompareArray(Uv2, other.Uv2)
+                || !CompareArray(Uv3, other.Uv3)
+                || !CompareArray(Uv4, other.Uv4)
+                || !CompareArray(Colors, other.Colors)
+                || !CompareArray(BoneWeights, other.BoneWeights)
+                || !CompareArray(Topology, other.Topology)
+                || !CompareArray(DrawModes, other.DrawModes)
+                || !CompareArray2(MorphTargetVertices, other.MorphTargetVertices)
+                || !CompareArray2(MorphTargetNormals, other.MorphTargetNormals)
+                || !CompareArray2(MorphTargetTangents, other.MorphTargetTangents)
+                || !CompareArray2(Indices, other.Indices))
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/Runtime/Scripts/SceneImporter/UnityMeshData.cs.meta
+++ b/Runtime/Scripts/SceneImporter/UnityMeshData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5142460d60f647e0b377dd3cc0c0a909
+timeCreated: 1724924750


### PR DESCRIPTION
New Import Options: Resource Deduplication for Meshes and Textures

Searches for identical Meshes/Textures on import and remaps/replaces the corresponding id's.
For referenced images by URIs, only the URI will be taken for comparision, not the image data inside the files.

