### PR TITLE
added gltf Asset informations to Importer Inspector

### DIFF
--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -110,7 +110,7 @@ namespace UnityGLTF
         [SerializeField] internal bool _useSceneNameIdentifier = false;
         [Tooltip("Compress textures after import using the platform default settings. If you need more control, use a .gltf file instead.")]
         [SerializeField] internal GLTFImporterTextureCompressionQuality _textureCompression = GLTFImporterTextureCompressionQuality.None;
-        
+        [SerializeField, Multiline] internal string _gltfAsset = default;
         // for humanoid importer
         [SerializeField] internal bool m_OptimizeGameObjects = false;
         [SerializeField] internal HumanDescription m_HumanDescription = new HumanDescription();
@@ -959,7 +959,7 @@ namespace UnityGLTF
 			    scene = loader.LastLoadedScene;
 			    animationClips = loader.CreatedAnimationClips;
 
-
+			    _gltfAsset = loader.Root.Asset.ToString(true);
 			    importer = loader;
 		    }
 	    }

--- a/Editor/Scripts/GLTFImporterInspector.cs
+++ b/Editor/Scripts/GLTFImporterInspector.cs
@@ -40,6 +40,7 @@ namespace UnityGLTF
 				AddTab(new GLTFAssetImporterTab(this, "Materials", MaterialInspectorGUI));
 
 			AddTab(new GLTFAssetImporterTab(this, "Used Extensions", ExtensionInspectorGUI));
+			AddTab(new GLTFAssetImporterTab(this, "Info", AssetInfoInspectorGUI));
 
 			base.OnEnable();
 		}
@@ -360,6 +361,28 @@ namespace UnityGLTF
 			}
 
 			EditorGUILayout.EndFoldoutHeaderGroup();
+		}
+
+		private void AssetInfoInspectorGUI()
+		{
+			var t = target as GLTFImporter;
+			if (!t) return;
+			var assetProp = serializedObject.FindProperty(nameof(GLTFImporter._gltfAsset));
+			if (assetProp == null)
+				return;
+
+			if (string.IsNullOrEmpty(t._gltfAsset))
+			{
+				EditorGUILayout.LabelField("[ No informations included ]");
+				return;
+			}
+			GUIStyle style = new GUIStyle(GUI.skin.label);
+			style.richText = true;
+			style.wordWrap = true;
+			EditorGUILayout.Space();
+			
+			var rect = GUILayoutUtility.GetRect(new GUIContent(t._gltfAsset), style);
+			EditorGUI.SelectableLabel(rect, t._gltfAsset, style);
 		}
 
 		private void ExtensionInspectorGUI()

--- a/Runtime/Plugins/GLTFSerialization/Schema/Asset.cs
+++ b/Runtime/Plugins/GLTFSerialization/Schema/Asset.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using Newtonsoft.Json;
 
 namespace GLTF.Schema
@@ -100,6 +101,40 @@ namespace GLTF.Schema
 			base.Serialize(writer);
 
 			writer.WriteEndObject();
+		}
+
+		public override string ToString()
+		{
+			return ToString(false);
+		}
+		
+		public string ToString(bool richFormat)
+		{
+			string bStart = richFormat ? "<b>" : "";
+			string bEnd = richFormat ? "</b>" : "";
+			
+			var sb = new StringBuilder();
+			if (!string.IsNullOrEmpty(Generator))
+				sb.AppendLine($"{bStart}{nameof(Generator)}: {bEnd}{Generator}");
+			
+			if (!string.IsNullOrEmpty(Version))
+				sb.AppendLine($"{bStart}{nameof(Version)}: {bEnd}{Version}");
+			
+			if (!string.IsNullOrEmpty(MinVersion))
+				sb.AppendLine($"{bStart}{nameof(MinVersion)}: {bEnd}{MinVersion}");
+			
+			if (!string.IsNullOrEmpty(Copyright))
+				sb.AppendLine($"{bStart}{nameof(Copyright)}: {bEnd}{Copyright}");
+			    
+			if (Extras != null)
+			{
+				sb.AppendLine("");
+				sb.AppendLine($"{bStart}Extras: {bEnd}");
+				foreach (var extra in Extras)
+					sb.AppendLine(extra.ToString());
+			}
+
+			return sb.ToString();
 		}
 	}
 }


### PR DESCRIPTION
Enhanced the importer inspector to show the gltf asset informations: 

![image](https://github.com/user-attachments/assets/a67ab394-5ed1-460e-9cf4-9683a35f9aeb)
![image](https://github.com/user-attachments/assets/21a254cb-bd0c-420c-b202-1abcda860c1d)

The informations will be stored in the importer as a multiline string from the new ToString methods in the gltf "Asset" class.