### PR TITLE
Load from stream enhancement

### DIFF
--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -328,6 +328,17 @@ namespace UnityGLTF
 			VerifyDataLoader();
 		}
 
+		public GLTFSceneImporter(Stream gltfStream, ImportOptions options) : this(options)
+		{
+			if (gltfStream != null)
+			{
+				_gltfStream = new GLBStream { Stream = gltfStream, StartPosition = gltfStream.Position };
+			}
+			GLTFParser.ParseJson(_gltfStream.Stream, out _gltfRoot, _gltfStream.StartPosition);
+
+			VerifyDataLoader();
+		}
+		
 		private GLTFSceneImporter(ImportOptions options)
 		{
 			if (options.ImportContext != null)

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -403,6 +403,11 @@ namespace UnityGLTF
 			{
 				if (_options.ExternalDataLoader == null)
 				{
+					if (string.IsNullOrEmpty(_gltfFileName))
+					{
+						Debug.Log(LogType.Warning, "No filename specified for GLTFSceneImporter, external references will not be loaded");
+						return;
+					}
 					_options.DataLoader = new UnityWebRequestLoader(URIHelper.GetDirectoryName(_gltfFileName));
 					_gltfFileName = URIHelper.GetFileFromUri(new Uri(_gltfFileName));
 				}

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -327,7 +327,19 @@ namespace UnityGLTF
 
 			VerifyDataLoader();
 		}
-
+		
+		/// <summary>
+		/// Loads a glTF file from a stream. It's recommended to load only gltf data without any external references. 
+		/// </summary>
+		/// <example>
+		/// <code>
+		/// var stream = new FileStream(filePath, FileMode.Open);
+		///	var importOptions = new ImportOptions();
+		///	var importer = new GLTFSceneImporter(stream, importOptions);
+		///	await importer.LoadSceneAsync();
+		///	stream.Dispose();
+		/// </code>
+		/// </example>
 		public GLTFSceneImporter(Stream gltfStream, ImportOptions options) : this(options)
 		{
 			if (gltfStream != null)


### PR DESCRIPTION
Added new GLTFSceneImporter constructor for easier loading from a stream. Includes an example in the summary of the constructor.
`public GLTFSceneImporter(Stream gltfStream, ImportOptions options)`

Also fixed a nullref error on VerifyDataLoader when no dataloader and filename is assigned and added a warning that is not possible to load referenced data on this condition.

