### PR TITLE
Feature: Shader Pass Stripping

### DIFF
--- a/Editor/Scripts/GLTFSettingsInspector.cs
+++ b/Editor/Scripts/GLTFSettingsInspector.cs
@@ -58,11 +58,12 @@ namespace UnityGLTF
 
 		private static SerializedObject m_SerializedObject;
 		private static int m_ActiveEditorIndex = 0;
-		private static readonly string[] m_TabNames = new string[2] { "Export", "Import" };
+		private static readonly string[] m_TabNames = new string[3] { "Export", "Import", "Build" };
 		private static readonly string key = typeof(GLTFSettings) + "ActiveEditorIndex";
 		
 		internal static void DrawGLTFSettingsGUI(GLTFSettings settings, SerializedObject m_SerializedObject)
 		{
+			var shaderStripping = m_SerializedObject.FindProperty(nameof(GLTFSettings.shaderStrippingSettings));
 			EditorGUIUtility.labelWidth = 220;
 			m_SerializedObject.Update();
 			
@@ -81,6 +82,15 @@ namespace UnityGLTF
 				GUILayout.FlexibleSpace();
 			}
 
+			if (m_ActiveEditorIndex == 2)
+			{
+				EditorGUI.BeginChangeCheck();
+				EditorGUILayout.PropertyField(shaderStripping);
+				if (EditorGUI.EndChangeCheck())
+					m_SerializedObject.ApplyModifiedProperties();
+				
+			}
+			else
 			if (m_ActiveEditorIndex == 1)
 			{
 				var tooltip = "These plugins are enabled by default when importing a glTF file at runtime.\nFor assets imported in the editor, adjust plugin settings on the respective importer.";
@@ -105,6 +115,8 @@ namespace UnityGLTF
 				{
 					do
 					{
+						if (prop.name == shaderStripping.name)
+							continue;
 						EditorGUILayout.PropertyField(prop, true);
 						switch (prop.name)
 						{

--- a/Editor/Scripts/ShaderGraph/ShaderPassStripping.cs
+++ b/Editor/Scripts/ShaderGraph/ShaderPassStripping.cs
@@ -3,61 +3,62 @@ using System.Linq;
 using UnityEngine;
 using UnityEditor.Build;
 using UnityEditor.Rendering;
-using UnityGLTF;
 
-class ShaderPassStripping : IPreprocessShaders
+namespace UnityGLTF
 {
-  
-    private static readonly string[] buildInPasses = new[]
+    internal class ShaderPassStripping : IPreprocessShaders
     {
-        "BuiltIn Forward", 
-        "BuiltIn ForwardAdd", 
-        "BuiltIn Deferred",
-    };
-    
-    private static readonly string[] urpDeferredPasses = new[]
-    {
-        "GBuffer", 
-    };
-
-    private static readonly string[] urpForwardPasses = new[]
-    {
-        "Universal ForwardAdd", 
-        // Ignore ForwardOnly pass, because it can also be used for Deferred rendering!
-    };
-
-    
-    // Use callbackOrder to set when Unity calls this shader preprocessor. Unity starts with the preprocessor that has the lowest callbackOrder value.
-    public int callbackOrder { get { return 0; } }
-    public GLTFSettings.ShaderStrippingSettings settings;
-    
-    public ShaderPassStripping()
-    {
-        if (GLTFSettings.TryGetSettings(out var s))
-            settings = s.shaderStrippingSettings;
-    }
-
-    private bool ShouldStripPass(ShaderSnippetData snippet)
-    {
-        if (settings.stripPasses.HasFlag(GLTFSettings.ShaderStrippingSettings.ShaderPassStrippingMode.URPDeferredPasses) && urpDeferredPasses.Contains(snippet.passName))
-            return true;
-        if (settings.stripPasses.HasFlag(GLTFSettings.ShaderStrippingSettings.ShaderPassStrippingMode.URPForwardPasses) && urpForwardPasses.Contains(snippet.passName))
-            return true;
-        if (settings.stripPasses.HasFlag(GLTFSettings.ShaderStrippingSettings.ShaderPassStrippingMode.BuildInPasses) && buildInPasses.Contains(snippet.passName))
-            return true;
-        return false;
-    }
-    
-    public void OnProcessShader(
-        Shader shader, ShaderSnippetData snippet, IList<ShaderCompilerData> data)
-    {
-        if (!settings.stripPassesFromAllShaders && !shader.name.Contains("UnityGLTF/PBRGraph"))
-            return;
-        
-        if (ShouldStripPass(snippet))
+        private static readonly string[] builtInPasses = new[]
         {
-            Debug.LogFormat(LogType.Log, LogOption.NoStacktrace, null, "Stripping shader: {0} with pass: {1}", shader.name, snippet.passName);
-            data.Clear();
+            "BuiltIn Forward", 
+            "BuiltIn ForwardAdd", 
+            "BuiltIn Deferred",
+        };
+        
+        private static readonly string[] urpDeferredPasses = new[]
+        {
+            "GBuffer", 
+        };
+
+        private static readonly string[] urpForwardPasses = new[]
+        {
+            "Universal ForwardAdd", 
+            // Ignore ForwardOnly pass, because it can also be used for Deferred rendering!
+        };
+
+        
+        // Use callbackOrder to set when Unity calls this shader preprocessor. Unity starts with the preprocessor that has the lowest callbackOrder value.
+        public int callbackOrder => 0;
+        public GLTFSettings.ShaderStrippingSettings settings;
+        
+        public ShaderPassStripping()
+        {
+            if (GLTFSettings.TryGetSettings(out var s))
+                settings = s.shaderStrippingSettings;
+        }
+
+        private bool ShouldStripPass(ShaderSnippetData snippet)
+        {
+            if (settings.stripPasses.HasFlag(GLTFSettings.ShaderStrippingSettings.ShaderPassStrippingMode.URPDeferredPasses) && urpDeferredPasses.Contains(snippet.passName))
+                return true;
+            if (settings.stripPasses.HasFlag(GLTFSettings.ShaderStrippingSettings.ShaderPassStrippingMode.URPForwardPasses) && urpForwardPasses.Contains(snippet.passName))
+                return true;
+            if (settings.stripPasses.HasFlag(GLTFSettings.ShaderStrippingSettings.ShaderPassStrippingMode.BuiltInPasses) && builtInPasses.Contains(snippet.passName))
+                return true;
+            return false;
+        }
+        
+        public void OnProcessShader(
+            Shader shader, ShaderSnippetData snippet, IList<ShaderCompilerData> data)
+        {
+            if (!settings.stripPassesFromAllShaders && !shader.name.Contains("UnityGLTF/PBRGraph"))
+                return;
+            
+            if (ShouldStripPass(snippet))
+            {
+                Debug.LogFormat(LogType.Log, LogOption.NoStacktrace, null, "Stripping UnityGLTF shader: {0} with pass: {1}", shader.name, snippet.passName);
+                data.Clear();
+            }
         }
     }
 }

--- a/Editor/Scripts/ShaderGraph/ShaderPassStripping.cs
+++ b/Editor/Scripts/ShaderGraph/ShaderPassStripping.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEditor.Build;
+using UnityEditor.Rendering;
+using UnityGLTF;
+
+class ShaderPassStripping : IPreprocessShaders
+{
+  
+    private static readonly string[] buildInPasses = new[]
+    {
+        "BuiltIn Forward", 
+        "BuiltIn ForwardAdd", 
+        "BuiltIn Deferred",
+    };
+    
+    private static readonly string[] urpDeferredPasses = new[]
+    {
+        "GBuffer", 
+    };
+
+    private static readonly string[] urpForwardPasses = new[]
+    {
+        "Universal ForwardAdd", 
+        // Ignore ForwardOnly pass, because it can also be used for Deferred rendering!
+    };
+
+    
+    // Use callbackOrder to set when Unity calls this shader preprocessor. Unity starts with the preprocessor that has the lowest callbackOrder value.
+    public int callbackOrder { get { return 0; } }
+    public GLTFSettings.ShaderStrippingSettings settings;
+    
+    public ShaderPassStripping()
+    {
+        if (GLTFSettings.TryGetSettings(out var s))
+            settings = s.shaderStrippingSettings;
+    }
+
+    private bool ShouldStripPass(ShaderSnippetData snippet)
+    {
+        if (settings.stripPasses.HasFlag(GLTFSettings.ShaderStrippingSettings.ShaderPassStrippingMode.URPDeferredPasses) && urpDeferredPasses.Contains(snippet.passName))
+            return true;
+        if (settings.stripPasses.HasFlag(GLTFSettings.ShaderStrippingSettings.ShaderPassStrippingMode.URPForwardPasses) && urpForwardPasses.Contains(snippet.passName))
+            return true;
+        if (settings.stripPasses.HasFlag(GLTFSettings.ShaderStrippingSettings.ShaderPassStrippingMode.BuildInPasses) && buildInPasses.Contains(snippet.passName))
+            return true;
+        return false;
+    }
+    
+    public void OnProcessShader(
+        Shader shader, ShaderSnippetData snippet, IList<ShaderCompilerData> data)
+    {
+        if (!settings.stripPassesFromAllShaders && !shader.name.Contains("UnityGLTF/PBRGraph"))
+            return;
+        
+        if (ShouldStripPass(snippet))
+        {
+            Debug.LogFormat(LogType.Log, LogOption.NoStacktrace, null, "Stripping shader: {0} with pass: {1}", shader.name, snippet.passName);
+            data.Clear();
+        }
+    }
+}

--- a/Editor/Scripts/ShaderGraph/ShaderPassStripping.cs.meta
+++ b/Editor/Scripts/ShaderGraph/ShaderPassStripping.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7d3ea702ff5a4e9d8f7dea1a97d69ee1
+timeCreated: 1726734748

--- a/Runtime/Scripts/GLTFSettings.cs
+++ b/Runtime/Scripts/GLTFSettings.cs
@@ -28,6 +28,27 @@ namespace UnityGLTF
 		    Tangent = 4,
 		    All = ~0
 	    }
+	    
+#if UNITY_EDITOR
+	    [Serializable]
+	    public class ShaderStrippingSettings
+	    {
+		    [Flags]
+		    public enum ShaderPassStrippingMode
+		    {
+			    None = 0,
+			    BuildInPasses = 1,
+			    URPForwardPasses = 2,
+			    URPDeferredPasses = 4,
+		    }
+		    
+		    public bool stripPassesFromAllShaders = false;
+		    public ShaderPassStrippingMode stripPasses = ShaderPassStrippingMode.None;
+	    }
+	    
+	    [Tooltip("Strip unnecessary shader passes from built-in and URP shader passes. This can drastically reduce shader compile time and size.")]
+	    public ShaderStrippingSettings shaderStrippingSettings = new ShaderStrippingSettings();
+#endif
 
 	    // Plugins
 	    [SerializeField, HideInInspector]

--- a/Runtime/Scripts/GLTFSettings.cs
+++ b/Runtime/Scripts/GLTFSettings.cs
@@ -37,7 +37,7 @@ namespace UnityGLTF
 		    public enum ShaderPassStrippingMode
 		    {
 			    None = 0,
-			    BuildInPasses = 1,
+			    BuiltInPasses = 1,
 			    URPForwardPasses = 2,
 			    URPDeferredPasses = 4,
 		    }


### PR DESCRIPTION
Added new Gltf Settings and shader pass stripping script:

![image](https://github.com/user-attachments/assets/3915b104-0b3c-4905-ab30-609f044aeab6)

To reduce shader compile time and resulting shader size, it's now possible to select shader passes which should be stripped on built process. e.g. Unity don't strip BuildIn RP passes, even when URP/HDRP is used. Also URP Deferred passes when only Forward is used. 

In editor log when building, the stripped shader passes can be found as:  
![image](https://github.com/user-attachments/assets/d8aba97d-bef2-4bdc-b8ab-0a3d0ee5d486)
