### PR TITLE
Fix #782 - Canvas export on webGl build

### DIFF
--- a/Runtime/Scripts/Plugins/Experimental/CanvasExport.cs
+++ b/Runtime/Scripts/Plugins/Experimental/CanvasExport.cs
@@ -37,7 +37,12 @@ namespace UnityGLTF.Plugins
 
             // force refresh
             var r = transform.GetComponent<CanvasRenderer>();
-            if (r) r.GetType().GetMethod("RequestRefresh", (BindingFlags)(-1)).Invoke(r, null);
+            if (r)
+            {
+                var rMethod = r.GetType().GetMethod("RequestRefresh", (BindingFlags)(-1));
+                if (rMethod != null)
+                    rMethod.Invoke(r, null);
+            }
             
             var canvas = g.GetComponent<Graphic>() ? g.GetComponent<Graphic>().canvas : null;
             var canvasRect = canvas ? canvas.GetComponent<RectTransform>().rect : new Rect(0,0,1000,1000);


### PR DESCRIPTION
Added null check for reflection get method "RequestRefresh" of canvas. Seems method does not exist in build. 