### PR TITLE
Fixes: Canvas and TMP Export, GltfPlugin enabled serialization

### DIFF
--- a/Editor/Scripts/GLTFSettingsInspector.cs
+++ b/Editor/Scripts/GLTFSettingsInspector.cs
@@ -179,6 +179,7 @@ namespace UnityGLTF
 				var expanded = SessionState.GetBool(key, false);
 				using (new GUILayout.HorizontalScope())
 				{
+					bool wasEnabled = plugin.Enabled;
 					if (plugin.AlwaysEnabled || !allowDisabling)
 					{
 						plugin.Enabled = true;
@@ -192,6 +193,8 @@ namespace UnityGLTF
 					{
 						plugin.Enabled = GUILayout.Toggle(plugin.Enabled, "", GUILayout.Width(12));
 					}
+					if (plugin.Enabled != wasEnabled)
+						EditorUtility.SetDirty(plugin);
 
 					var label = new GUIContent(displayName, plugin.Description);
 					EditorGUI.BeginDisabledGroup(!plugin.Enabled);

--- a/Runtime/Scripts/Plugins/Core/GltfPlugin.cs
+++ b/Runtime/Scripts/Plugins/Core/GltfPlugin.cs
@@ -37,7 +37,7 @@ namespace UnityGLTF.Plugins
         public virtual string Description => null;
         public virtual string HelpUrl => null;
         
-        [SerializeField] private bool enabled = true;
+        [SerializeField] [HideInInspector] private bool enabled = true;
         public virtual bool Enabled
         {
 	        get

--- a/Runtime/Scripts/Plugins/Core/GltfPlugin.cs
+++ b/Runtime/Scripts/Plugins/Core/GltfPlugin.cs
@@ -36,7 +36,19 @@ namespace UnityGLTF.Plugins
         public abstract string DisplayName { get; }
         public virtual string Description => null;
         public virtual string HelpUrl => null;
-        public bool Enabled { get; set; } = true;
+        
+        [SerializeField] private bool enabled = true;
+        public virtual bool Enabled
+        {
+	        get
+	        {
+		        return enabled || AlwaysEnabled; 
+	        }
+	        set
+	        {
+		        enabled = value;
+	        }
+        }
         public virtual bool EnabledByDefault => true;
         public virtual bool AlwaysEnabled => false;
         public virtual string Warning => null;

--- a/Runtime/Scripts/Plugins/Experimental/CanvasExport.cs
+++ b/Runtime/Scripts/Plugins/Experimental/CanvasExport.cs
@@ -27,10 +27,15 @@ namespace UnityGLTF.Plugins
             // emit mesh and material if this is a Graphic element in a Canvas that's not disabled
             if (!shader)
             {
-                shader = Shader.Find("Hidden/UnityGLTF/UnlitGraph-Transparent");
+                shader = Shader.Find("UnityGLTF/UnlitGraph");
 #if UNITY_EDITOR
-                if (!shader) shader = AssetDatabase.LoadAssetAtPath<Shader>(AssetDatabase.GUIDToAssetPath("83f2caca07949794fb997734c4b0520f"));
+                if (!shader) shader = AssetDatabase.LoadAssetAtPath<Shader>(AssetDatabase.GUIDToAssetPath("59541e6caf586ca4f96ccf48a4813a51"));
 #endif
+                if (!shader)
+                {
+                    Debug.LogError("CanvasExport: Shader not found. Please make sure the UnityGLTF/UnlitGraph shader is included in build or add the UnityGLTFShaderVariantCollection in Project Settings/Graphics.");
+                    return;
+                }
             }
             
             var g = transform;

--- a/Runtime/Scripts/Plugins/Experimental/CanvasExportCaptureMeshHelper.cs
+++ b/Runtime/Scripts/Plugins/Experimental/CanvasExportCaptureMeshHelper.cs
@@ -37,6 +37,7 @@ namespace UnityGLTF.Plugins
                 return false;
             }
             
+            g.SetVerticesDirty();
             g.Rebuild(CanvasUpdate.PreRender);
 
             mesh = this.mesh;

--- a/Runtime/Scripts/Plugins/Experimental/CanvasExportCaptureMeshHelper.cs
+++ b/Runtime/Scripts/Plugins/Experimental/CanvasExportCaptureMeshHelper.cs
@@ -53,7 +53,11 @@ namespace UnityGLTF.Plugins
                 material = tmPro.fontSharedMaterial;
             }
 #endif
-            if (!material) material = new Material(shader);
+            if (!material)
+            {
+                material = new Material(shader);
+                material.SetOverrideTag("RenderType", "Transparent");
+            }
             
             if (!hasTMPro)
             {

--- a/Runtime/Scripts/Plugins/Experimental/TextMeshGameObjectExport.cs
+++ b/Runtime/Scripts/Plugins/Experimental/TextMeshGameObjectExport.cs
@@ -50,6 +50,12 @@ namespace UnityGLTF.Plugins
 					newS = UnityEditor.AssetDatabase.LoadAssetAtPath<Shader>(UnityEditor.AssetDatabase.GUIDToAssetPath("fe393ace9b354375a9cb14cdbbc28be4")); // same as above
 				}
 #endif
+				if (!newS)
+				{
+					Debug.LogError("TextMeshPro/Mobile/Distance Field shader not found. For exporting TextMeshPro GameObjects, please ensure this shader exist in build.");
+					return false;
+				}
+				
 				material.shader = newS;
 
 				if (!tempMat) tempMat = new Material(Shader.Find("Unlit/Transparent Cutout"));

--- a/Runtime/Scripts/Plugins/Experimental/TextMeshGameObjectExport.cs
+++ b/Runtime/Scripts/Plugins/Experimental/TextMeshGameObjectExport.cs
@@ -51,7 +51,7 @@ namespace UnityGLTF.Plugins
 #endif
 				if (!newS)
 				{
-					Debug.LogError("TrextMeshPro/Mobile/Distance Field shader not found. For exporting TextMeshPro GameObjects, please ensure this shader exist in build.");
+					Debug.LogError("TextMeshPro/Mobile/Distance Field shader not found. For exporting TextMeshPro GameObjects, please ensure this shader exist in build.");
 					return false;
 				}
 


### PR DESCRIPTION
TMP Export:
- removed the requirement of "Unlit/Transparent Cutout" shader and "tempMat"-Material
- added error log output when ""TextMeshPro/Mobile/Distance Field" shader was not found
- restoring "_OutlineSoftness" value of exported TMP-Material after export

Canvas Export:
- replaced deprecated "Hidden/UnityGLTF/UnlitGraph-Transparent" shader with "UnityGltf/UnlitGraph" shader when exporting
- added error log output when shader not found 

GltfPlugin:
- fixed non-serialized "enabled" state 


Fixes all issues of [#782](https://github.com/KhronosGroup/UnityGLTF/issues/782)