### PR TITLE
Fixed: removed internal Unity Method TextureImporter.GetFixedPlatformName from Unity 6000

### DIFF
--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -702,8 +702,7 @@ namespace UnityGLTF
 		                        if (_textureCompression != GLTFImporterTextureCompressionQuality.None)
 		                        {
 			                        // platform-dependant texture compression
-			                        var buildTargetName = BuildPipeline.GetBuildTargetName(ctx.selectedBuildTarget);
-			                        var format = TextureImporterHelper.GetAutomaticFormat(tex, buildTargetName);
+			                        var format = TextureImporterHelper.GetAutomaticFormat(tex);
 			                        var convertedFormat = (TextureFormat)(int)format;
 			                        if ((int)convertedFormat > -1)
 			                        {

--- a/Editor/Scripts/GLTFSettingsInspector.cs
+++ b/Editor/Scripts/GLTFSettingsInspector.cs
@@ -167,6 +167,7 @@ namespace UnityGLTF
 			foreach (var plugin in plugins
 				         .OrderBy(x =>
 				         {
+							if (!x) return "ZZZ";
 					         var displayName = x.GetType().Assembly.GetName().Name;
 					         if (displayName == "UnityGLTFScripts") displayName = "____";
 					         return displayName;

--- a/Editor/Scripts/Internal/TextureImporterHelper.cs
+++ b/Editor/Scripts/Internal/TextureImporterHelper.cs
@@ -8,22 +8,13 @@ namespace UnityGLTF
 {
     public class TextureImporterHelper
     {
-        private static MethodInfo GetFixedPlatformName;
         private const string DefaultTextureAssetGuid = "7b7ff3cec11c24c599d6f12443877d5e";
         
-        public static TextureImporterFormat GetAutomaticFormat(Texture2D texture, string platform)
+        public static TextureImporterFormat GetAutomaticFormat(Texture2D texture)
         {
             var defaultTextureImporter = AssetImporter.GetAtPath(AssetDatabase.GUIDToAssetPath(DefaultTextureAssetGuid)) as TextureImporter;
             // defaultTextureImporter = new TextureImporter();
-
-            if (GetFixedPlatformName == null)
-                GetFixedPlatformName = typeof(TextureImporter)
-                    .GetMethod("GetFixedPlatformName", BindingFlags.Static | BindingFlags.NonPublic);
             
-            if (GetFixedPlatformName == null)
-                throw new MissingMethodException("TextureImporter.GetFixedPlatformName");
-
-            platform = GetFixedPlatformName.Invoke(null, new object[] { platform }) as string;
             TextureImporterSettings importerSettings = new TextureImporterSettings();
             
             importerSettings.aniso = 5;
@@ -36,12 +27,13 @@ namespace UnityGLTF
             var isHDR = TextureUtil.IsHDRFormat(texture.format);
            
             // var platformSettings = new TextureImporterPlatformSettings();
-            
             foreach (BuildPlatform validPlatform in BuildPlatforms.instance.GetValidPlatforms())
             {
                 // TextureImporter.RecommendedFormatsFromTextureTypeAndPlatform
-                if (validPlatform.name == platform)
-                    return TextureImporter.DefaultFormatFromTextureParameters(importerSettings, defaultTextureImporter.GetPlatformTextureSettings(platform), hasAlpha, isHDR, validPlatform.defaultTarget);
+                if (validPlatform.IsActive())
+                {
+                    return TextureImporter.DefaultFormatFromTextureParameters(importerSettings, defaultTextureImporter.GetPlatformTextureSettings(validPlatform.name), hasAlpha, isHDR, validPlatform.defaultTarget);
+                }
             }
             
             // This should never happen

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -502,7 +502,10 @@ namespace UnityGLTF
 			}
 			_gltfStream.Stream.Close();
 			DisposeNativeBuffers();
-
+			
+			if (this.progress != null)
+				await Task.Yield();
+			
 			onLoadComplete?.Invoke(LastLoadedScene, null);
 		}
 

--- a/Runtime/Scripts/Loader/FileLoader.cs
+++ b/Runtime/Scripts/Loader/FileLoader.cs
@@ -60,6 +60,11 @@ namespace UnityGLTF.Loader
 		}
 		public Task<Stream> LoadStreamAsync(string relativeFilePath)
 		{
+			if (relativeFilePath.StartsWith("http://") || relativeFilePath.StartsWith("https://"))
+			{
+				return new UnityWebRequestLoader("").LoadStreamAsync(relativeFilePath);
+			}
+			
 #if UNITY_EDITOR
 			string path = CombinePaths(_rootDirectoryPath, relativeFilePath);
 
@@ -99,7 +104,7 @@ namespace UnityGLTF.Loader
 			string pathToLoad = Path.Combine(_rootDirectoryPath, relativeFilePath);
 			if (!File.Exists(pathToLoad))
 			{
-				pathToLoad = Path.Combine(_rootDirectoryPath, Uri.UnescapeDataString(relativeFilePath));
+				pathToLoad = Uri.UnescapeDataString(Path.Combine(_rootDirectoryPath, relativeFilePath));
 			}
 
 			if (!File.Exists(pathToLoad))

--- a/Runtime/Scripts/RenderPipelines/RoughRefractionFeature.cs
+++ b/Runtime/Scripts/RenderPipelines/RoughRefractionFeature.cs
@@ -115,7 +115,12 @@ namespace UnityGLTF
 	                descriptor.height /= 4;
 	            }
 #if UNITY_2022_3_OR_NEWER
+
+#if UNITY_6000_0_OR_NEWER
+		        RenderingUtils.ReAllocateHandleIfNeeded(ref m_destination, descriptor, FilterMode.Trilinear, TextureWrapMode.Clamp, name: CAMERA_OPAQUE_TEXTURENAME);
+#else
 		        RenderingUtils.ReAllocateIfNeeded(ref m_destination, descriptor, FilterMode.Trilinear, TextureWrapMode.Clamp, name: CAMERA_OPAQUE_TEXTURENAME);
+#endif
 		        base.Setup(m_source, m_destination, this.m_DownsamplingMethod);
 		        cmd.SetGlobalTexture(m_destination.name, m_destination.nameID);
 #else


### PR DESCRIPTION
Replaced reflection invoke of internal GetFixedPlatformName method with IsActive checking from the EditorUserBuildSettingsUtils extension to determine current platform name.

Testet with:
Unity 6000.0.40f1
Unity 2022.2.46f1
Unity 2021.3.36f1