### PR TITLE
Fix: material blendmode setup

### DIFF
--- a/Editor/Scripts/PbrShaderGUI.cs
+++ b/Editor/Scripts/PbrShaderGUI.cs
@@ -230,6 +230,7 @@ namespace UnityEditor
                     material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
                     material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.AlphaTest;
                     material.SetFloat("_Cutoff", alphaCutoff);
+                    material.SetFloat("_AlphaToMask", 1f);
                     break;
                 case BlendMode.Blend:
                     material.SetOverrideTag("RenderType", "Transparent");
@@ -239,6 +240,8 @@ namespace UnityEditor
                     material.DisableKeyword("_ALPHATEST_ON");
                     material.EnableKeyword("_ALPHABLEND_ON");
                     material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                    material.SetFloat("_BlendModePreserveSpecular", 0);
+                    material.SetFloat("_AlphaToMask", 0);
                     material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
                     break;
             }

--- a/Runtime/Scripts/UniformMaps/BaseGraphMap.cs
+++ b/Runtime/Scripts/UniformMaps/BaseGraphMap.cs
@@ -85,7 +85,8 @@ namespace UnityGLTF
 				    _material.renderQueue = (int)RenderQueue.Transparent;
 				    _material.EnableKeyword("_SURFACE_TYPE_TRANSPARENT");
 				    _material.EnableKeyword("_BUILTIN_SURFACE_TYPE_TRANSPARENT");
-
+				    _material.SetFloat("_BlendModePreserveSpecular", 0);
+			
 				    SetShaderModeBlend(_material);
 			    }
 			    else
@@ -136,6 +137,7 @@ namespace UnityGLTF
 		    material.SetFloat(k_AlphaClipBuiltin, 1);
 		    if (isMask) material.EnableKeyword(KW_ALPHACLIP_ON_BUILTIN);
 		    else material.DisableKeyword(KW_ALPHACLIP_ON_BUILTIN);
+		    material.SetFloat(alphaToMask, isMask ? 1 : 0);
 	    }
 
 	    static readonly int cullPropId = Shader.PropertyToID("_Cull");
@@ -150,7 +152,8 @@ namespace UnityGLTF
 	    static readonly int srcBlendPropId = Shader.PropertyToID("_SrcBlend");
 	    static readonly int dstBlendPropId = Shader.PropertyToID("_DstBlend");
 	    static readonly int zWritePropId = Shader.PropertyToID("_ZWrite");
-
+	    static readonly int alphaToMask = Shader.PropertyToID("_AlphaToMask");
+	    
 	    const string TAG_RENDER_TYPE = "RenderType";
 	    const string TAG_RENDER_TYPE_CUTOUT = "TransparentCutout";
 	    const string TAG_RENDER_TYPE_OPAQUE = "Opaque";
@@ -188,6 +191,7 @@ namespace UnityGLTF
 		    material.SetFloat(k_Surface, 1);
 		    material.SetFloat(k_SurfaceBuiltin, 1);
 		    material.SetFloat(zWritePropId, 0);
+		    material.SetFloat(alphaToMask, 0);
 	    }
 
 	    public double AlphaCutoff

--- a/Runtime/Scripts/UniformMaps/StandardMap.cs
+++ b/Runtime/Scripts/UniformMaps/StandardMap.cs
@@ -289,6 +289,7 @@ namespace UnityGLTF
 					{
 						_material.SetFloat("_Cutoff", (float)_alphaCutoff);
 					}
+					_material.SetFloat("_AlphaToMask", 1f);
 				}
 				else if (value == AlphaMode.BLEND)
 				{
@@ -301,6 +302,7 @@ namespace UnityGLTF
 					_material.EnableKeyword("_ALPHABLEND_ON");
 					_material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
 					_material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+					_material.SetFloat("_AlphaToMask", 0f);
 				}
 				else
 				{
@@ -313,6 +315,7 @@ namespace UnityGLTF
 					_material.DisableKeyword("_ALPHABLEND_ON");
 					_material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
 					_material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Geometry;
+					_material.SetFloat("_AlphaToMask", 0f);
 				}
 
 				_alphaMode = value;


### PR DESCRIPTION
Added missing material setup for AlphaToMask float value and BlendModePreserveSpecular float value.

AlphaToMask need to set to 0 when using Blend Mode Alpha, otherwise Unity is rendering the material in Mask mode.
This issue occurs only on runtime/playmode loaded models. Imported GLTFs was not affecting by not implicit setting the value to 0. Seems Unity was setting the right value by itself. 

Tested with:
[AlphaBlendModeTest.zip](https://github.com/user-attachments/files/19210290/AlphaBlendModeTest.zip)
