### PR TITLE
Basic HDRP export support

### DIFF
--- a/Runtime/Resources/MetalGlossChannelSwap.shader
+++ b/Runtime/Resources/MetalGlossChannelSwap.shader
@@ -4,6 +4,9 @@
 	{
 		_MainTex ("Texture", 2D) = "white" {}
 		_SmoothnessMultiplier ("Smoothness Multiplier", float) = 1
+		_SmoothnessMultiplier2 ("Smoothness Multiplier2", float) = 0
+		_MetallicMultiplier ("_MetallicMultiplier", float) = 1
+		_MetallicMultiplier2 ("_MetallicMultiplier2", float) = 0
 	}
 	SubShader
 	{
@@ -39,7 +42,12 @@
 			}
 			
 			sampler2D _MainTex;
+
+			float _MetallicMultiplier;
+			float _MetallicMultiplier2;
+
 			float _SmoothnessMultiplier;
+			float _SmoothnessMultiplier2;
 
 			float4 frag (v2f i) : SV_Target
 			{
@@ -55,7 +63,11 @@
 				// Conversion Summary
 				// Unity R channel goes into B channel
 				// Unity A channel goes into G channel, then inverted
-				float4 result = float4(0, 1 - (col.a * _SmoothnessMultiplier), col.r, 1);
+				float4 result = float4(
+					0,
+					1 - (_SmoothnessMultiplier2 + col.a * (_SmoothnessMultiplier - _SmoothnessMultiplier2)),
+					_MetallicMultiplier2 + col.r * (_MetallicMultiplier - _MetallicMultiplier2),
+					0);
 				return result;
 			}
 			ENDCG

--- a/Runtime/Resources/MetalGlossChannelSwap.shader
+++ b/Runtime/Resources/MetalGlossChannelSwap.shader
@@ -3,10 +3,10 @@
 	Properties
 	{
 		_MainTex ("Texture", 2D) = "white" {}
-		_SmoothnessMultiplier ("Smoothness Multiplier", float) = 1
-		_SmoothnessMultiplier2 ("Smoothness Multiplier2", float) = 0
-		_MetallicMultiplier ("_MetallicMultiplier", float) = 1
-		_MetallicMultiplier2 ("_MetallicMultiplier2", float) = 0
+		_SmoothnessRangeMin ("Smoothness Range Min", float) = 0
+		_SmoothnessRangeMax ("Smoothness Range Max", float) = 1
+		_MetallicRangeMin ("Metallic Range Min", float) = 0
+		_MetallicRangeMax ("Metallic Range Max", float) = 1
 	}
 	SubShader
 	{
@@ -43,11 +43,11 @@
 			
 			sampler2D _MainTex;
 
-			float _MetallicMultiplier;
-			float _MetallicMultiplier2;
+			float _MetallicRangeMin;
+			float _MetallicRangeMax;
 
-			float _SmoothnessMultiplier;
-			float _SmoothnessMultiplier2;
+			float _SmoothnessRangeMin;
+			float _SmoothnessRangeMax;
 
 			float4 frag (v2f i) : SV_Target
 			{
@@ -65,8 +65,8 @@
 				// Unity A channel goes into G channel, then inverted
 				float4 result = float4(
 					0,
-					1 - (_SmoothnessMultiplier2 + col.a * (_SmoothnessMultiplier - _SmoothnessMultiplier2)),
-					_MetallicMultiplier2 + col.r * (_MetallicMultiplier - _MetallicMultiplier2),
+					1 - (_SmoothnessRangeMin + col.a * (_SmoothnessRangeMax - _SmoothnessRangeMin)),
+					_MetallicRangeMin + col.r * (_MetallicRangeMax - _MetallicRangeMin),
 					0);
 				return result;
 			}

--- a/Runtime/Resources/MetalGlossOcclusionChannelSwap.shader
+++ b/Runtime/Resources/MetalGlossOcclusionChannelSwap.shader
@@ -3,7 +3,10 @@
 	Properties
 	{
 		_MainTex ("Texture", 2D) = "white" {}
-		_SmoothnessMultiplier ("Smoothness Multiplier", float) = 1
+		_SmoothnessRangeMin ("Smoothness Range Min", float) = 0
+		_SmoothnessRangeMax ("Smoothness Range Max", float) = 1
+		_MetallicRangeMin ("Metallic Range Min", float) = 0
+		_MetallicRangeMax ("Metallic Range Max", float) = 1
 	}
 	SubShader
 	{
@@ -39,7 +42,12 @@
 			}
 			
 			sampler2D _MainTex;
-			float _SmoothnessMultiplier;
+
+			float _MetallicRangeMin;
+			float _MetallicRangeMax;
+
+			float _SmoothnessRangeMin;
+			float _SmoothnessRangeMax;
 
 			float4 frag (v2f i) : SV_Target
 			{
@@ -56,7 +64,11 @@
 				// Unity R channel goes into B channel
 				// Unity A channel goes into G channel, then inverted
 				// Unity G channel goes into R channel > Occlusion
-				float4 result = float4(col.g, 1 - (col.a * _SmoothnessMultiplier), col.r, 1);
+				float4 result = float4(
+					col.g,
+					1 - (_SmoothnessRangeMin + col.a * (_SmoothnessRangeMax - _SmoothnessRangeMin)),
+					_MetallicRangeMin + col.r * (_MetallicRangeMax - _MetallicRangeMin),
+					1);
 				return result;
 			}
 			ENDCG

--- a/Runtime/Resources/MetalGlossOcclusionChannelSwap.shader
+++ b/Runtime/Resources/MetalGlossOcclusionChannelSwap.shader
@@ -7,6 +7,8 @@
 		_SmoothnessRangeMax ("Smoothness Range Max", float) = 1
 		_MetallicRangeMin ("Metallic Range Min", float) = 0
 		_MetallicRangeMax ("Metallic Range Max", float) = 1
+		_OcclusionRangeMin ("Occlusion Range Min", float) = 0
+		_OcclusionRangeMax ("Occlusion Range Max", float) = 1
 	}
 	SubShader
 	{
@@ -49,6 +51,9 @@
 			float _SmoothnessRangeMin;
 			float _SmoothnessRangeMax;
 
+			float _OcclusionRangeMin;
+			float _OcclusionRangeMax;
+
 			float4 frag (v2f i) : SV_Target
 			{
 				float4 col = tex2D(_MainTex, i.uv);
@@ -65,10 +70,10 @@
 				// Unity A channel goes into G channel, then inverted
 				// Unity G channel goes into R channel > Occlusion
 				float4 result = float4(
-					col.g,
+					_OcclusionRangeMin + col.g * (_OcclusionRangeMax - _OcclusionRangeMin),
 					1 - (_SmoothnessRangeMin + col.a * (_SmoothnessRangeMax - _SmoothnessRangeMin)),
 					_MetallicRangeMin + col.r * (_MetallicRangeMax - _MetallicRangeMin),
-					1);
+					0);
 				return result;
 			}
 			ENDCG

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -190,14 +190,20 @@ namespace UnityGLTF
 			public bool linear;
 			// required for metallic-smoothness conversion
 			public float smoothnessMultiplier;
+			public float smoothnessMultiplier2;
+            public float metallicMultiplier;
+            public float metallicMultiplier2;
 
-			public TextureExportSettings(TextureExportSettings source)
+            public TextureExportSettings(TextureExportSettings source)
 			{
 				conversion = source.conversion;
 				alphaMode = source.alphaMode;
 				linear = source.linear;
 				smoothnessMultiplier = source.smoothnessMultiplier;
-				isValid = true;
+				smoothnessMultiplier2 = source.smoothnessMultiplier2;
+				metallicMultiplier = source.metallicMultiplier;
+				metallicMultiplier2 = source.metallicMultiplier2;
+                isValid = true;
 			}
 
 			public enum Conversion
@@ -247,7 +253,10 @@ namespace UnityGLTF
 					hashCode = (hashCode * 397) ^ (int)alphaMode;
 					hashCode = (hashCode * 397) ^ linear.GetHashCode();
 					hashCode = (hashCode * 397) ^ smoothnessMultiplier.GetHashCode();
-					return hashCode;
+					hashCode = (hashCode * 397) ^ smoothnessMultiplier2.GetHashCode();
+					hashCode = (hashCode * 397) ^ metallicMultiplier.GetHashCode();
+                    hashCode = (hashCode * 397) ^ metallicMultiplier2.GetHashCode();
+                    return hashCode;
 				}
 			}
 		}
@@ -256,8 +265,10 @@ namespace UnityGLTF
 		{
 			var exportSettings = new TextureExportSettings();
 			exportSettings.isValid = true;
+			exportSettings.metallicMultiplier = 1f;
+			exportSettings.smoothnessMultiplier = 1f;
 
-			switch (textureSlot)
+            switch (textureSlot)
 			{
 				case TextureMapType.BaseColor: // Main = new TextureExportSettings() { alphaMode = AlphaMode.Heuristic };
 					exportSettings.linear = false;
@@ -327,13 +338,22 @@ namespace UnityGLTF
 				case TextureExportSettings.Conversion.MetalGlossChannelSwap:
 					if (_metalGlossChannelSwapMaterial && _metalGlossChannelSwapMaterial.HasProperty("_SmoothnessMultiplier"))
 						_metalGlossChannelSwapMaterial.SetFloat("_SmoothnessMultiplier", textureMapType.smoothnessMultiplier);
+                    if (_metalGlossChannelSwapMaterial && _metalGlossChannelSwapMaterial.HasProperty("_SmoothnessMultiplier2"))
+                        _metalGlossChannelSwapMaterial.SetFloat("_SmoothnessMultiplier2", textureMapType.smoothnessMultiplier2);
+                    
+					if (_metalGlossChannelSwapMaterial && _metalGlossChannelSwapMaterial.HasProperty("_MetallicMultiplier"))
+                        _metalGlossChannelSwapMaterial.SetFloat("_MetallicMultiplier", textureMapType.metallicMultiplier);
+                    if (_metalGlossChannelSwapMaterial && _metalGlossChannelSwapMaterial.HasProperty("_MetallicMultiplier2"))
+                        _metalGlossChannelSwapMaterial.SetFloat("_MetallicMultiplier2", textureMapType.metallicMultiplier2);
 
-					return _metalGlossChannelSwapMaterial;
+                    return _metalGlossChannelSwapMaterial;
 				case TextureExportSettings.Conversion.MetalGlossOcclusionChannelSwap:
 					if (_metalGlossOcclusionChannelSwapMaterial && _metalGlossOcclusionChannelSwapMaterial.HasProperty("_SmoothnessMultiplier"))
 						_metalGlossOcclusionChannelSwapMaterial.SetFloat("_SmoothnessMultiplier", textureMapType.smoothnessMultiplier);
-					
-					return _metalGlossOcclusionChannelSwapMaterial;
+                    if (_metalGlossOcclusionChannelSwapMaterial && _metalGlossOcclusionChannelSwapMaterial.HasProperty("_SmoothnessMultiplier2"))
+                        _metalGlossOcclusionChannelSwapMaterial.SetFloat("_SmoothnessMultiplier2", textureMapType.smoothnessMultiplier2);
+
+                    return _metalGlossOcclusionChannelSwapMaterial;
 				default:
 					return null;
 			}

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -265,8 +265,8 @@ namespace UnityGLTF
 					hashCode = (hashCode * 397) ^ smoothnessRangeMax.GetHashCode();
 					hashCode = (hashCode * 397) ^ metallicRangeMin.GetHashCode();
 					hashCode = (hashCode * 397) ^ metallicRangeMax.GetHashCode();
-                    hashCode = (hashCode * 397) ^ occlusionRangeMin.GetHashCode();
-                    hashCode = (hashCode * 397) ^ occlusionRangeMax.GetHashCode();
+					hashCode = (hashCode * 397) ^ occlusionRangeMin.GetHashCode();
+					hashCode = (hashCode * 397) ^ occlusionRangeMax.GetHashCode();
 					return hashCode;
 				}
 			}

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -193,6 +193,8 @@ namespace UnityGLTF
 			public float smoothnessRangeMax;
             public float metallicRangeMin;
             public float metallicRangeMax;
+            public float occlusionRangeMin;
+            public float occlusionRangeMax;
 
             public TextureExportSettings(TextureExportSettings source)
 			{
@@ -203,6 +205,8 @@ namespace UnityGLTF
 				smoothnessRangeMax = source.smoothnessRangeMax;
 				metallicRangeMin = source.metallicRangeMin;
 				metallicRangeMax = source.metallicRangeMax;
+				occlusionRangeMin = source.occlusionRangeMin;
+				occlusionRangeMax = source.occlusionRangeMax;
                 isValid = true;
 			}
 
@@ -269,6 +273,8 @@ namespace UnityGLTF
 			exportSettings.metallicRangeMax = 1f;
             exportSettings.smoothnessRangeMin = 0f;
 			exportSettings.smoothnessRangeMax = 1f;
+			exportSettings.occlusionRangeMin = 0f;
+			exportSettings.occlusionRangeMax = 1f;
 
             switch (textureSlot)
 			{
@@ -358,7 +364,12 @@ namespace UnityGLTF
             if (material && material.HasProperty("_MetallicRangeMax"))
                 material.SetFloat("_MetallicRangeMax", textureMapType.metallicRangeMax);
 
-			return material;
+            if (material && material.HasProperty("_OcclusionRangeMin"))
+                material.SetFloat("_OcclusionRangeMin", textureMapType.occlusionRangeMin);
+            if (material && material.HasProperty("_OcclusionRangeMax"))
+                material.SetFloat("_OcclusionRangeMax", textureMapType.occlusionRangeMax);
+
+            return material;
         }
 
         private struct ImageInfo

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -241,7 +241,12 @@ namespace UnityGLTF
 					conversion == other.conversion &&
 				    alphaMode == other.alphaMode &&
 				    linear == other.linear &&
-					Mathf.Approximately(smoothnessRangeMax, other.smoothnessRangeMax);
+					Mathf.Approximately(smoothnessRangeMin, other.smoothnessRangeMin) &&
+					Mathf.Approximately(smoothnessRangeMax, other.smoothnessRangeMax) &&
+					Mathf.Approximately(metallicRangeMin, other.metallicRangeMin) &&
+					Mathf.Approximately(metallicRangeMax, other.metallicRangeMax) &&
+					Mathf.Approximately(occlusionRangeMin, other.occlusionRangeMin) &&
+					Mathf.Approximately(occlusionRangeMax, other.occlusionRangeMax);
 			}
 
 			public override bool Equals(object obj)
@@ -260,6 +265,8 @@ namespace UnityGLTF
 					hashCode = (hashCode * 397) ^ smoothnessRangeMax.GetHashCode();
 					hashCode = (hashCode * 397) ^ metallicRangeMin.GetHashCode();
 					hashCode = (hashCode * 397) ^ metallicRangeMax.GetHashCode();
+                    hashCode = (hashCode * 397) ^ occlusionRangeMin.GetHashCode();
+                    hashCode = (hashCode * 397) ^ occlusionRangeMax.GetHashCode();
 					return hashCode;
 				}
 			}

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -191,12 +191,12 @@ namespace UnityGLTF
 			// required for metallic-smoothness conversion
 			public float smoothnessRangeMin;
 			public float smoothnessRangeMax;
-            public float metallicRangeMin;
-            public float metallicRangeMax;
-            public float occlusionRangeMin;
-            public float occlusionRangeMax;
+			public float metallicRangeMin;
+			public float metallicRangeMax;
+			public float occlusionRangeMin;
+			public float occlusionRangeMax;
 
-            public TextureExportSettings(TextureExportSettings source)
+			public TextureExportSettings(TextureExportSettings source)
 			{
 				conversion = source.conversion;
 				alphaMode = source.alphaMode;
@@ -207,7 +207,7 @@ namespace UnityGLTF
 				metallicRangeMax = source.metallicRangeMax;
 				occlusionRangeMin = source.occlusionRangeMin;
 				occlusionRangeMax = source.occlusionRangeMax;
-                isValid = true;
+				isValid = true;
 			}
 
 			public enum Conversion
@@ -258,9 +258,9 @@ namespace UnityGLTF
 					hashCode = (hashCode * 397) ^ linear.GetHashCode();
 					hashCode = (hashCode * 397) ^ smoothnessRangeMin.GetHashCode();
 					hashCode = (hashCode * 397) ^ smoothnessRangeMax.GetHashCode();
-                    hashCode = (hashCode * 397) ^ metallicRangeMin.GetHashCode();
+					hashCode = (hashCode * 397) ^ metallicRangeMin.GetHashCode();
 					hashCode = (hashCode * 397) ^ metallicRangeMax.GetHashCode();
-                    return hashCode;
+					return hashCode;
 				}
 			}
 		}
@@ -271,12 +271,12 @@ namespace UnityGLTF
 			exportSettings.isValid = true;
 			exportSettings.metallicRangeMin = 0f;
 			exportSettings.metallicRangeMax = 1f;
-            exportSettings.smoothnessRangeMin = 0f;
+			exportSettings.smoothnessRangeMin = 0f;
 			exportSettings.smoothnessRangeMax = 1f;
 			exportSettings.occlusionRangeMin = 0f;
 			exportSettings.occlusionRangeMax = 1f;
 
-            switch (textureSlot)
+			switch (textureSlot)
 			{
 				case TextureMapType.BaseColor: // Main = new TextureExportSettings() { alphaMode = AlphaMode.Heuristic };
 					exportSettings.linear = false;
@@ -343,36 +343,36 @@ namespace UnityGLTF
 			{
 				case TextureExportSettings.Conversion.NormalChannel:
 					return _normalChannelMaterial;
-                case TextureExportSettings.Conversion.MetalGlossChannelSwap:
-                    return SetConversionMaterialSettings(_metalGlossChannelSwapMaterial, textureMapType);
-                case TextureExportSettings.Conversion.MetalGlossOcclusionChannelSwap:
+				case TextureExportSettings.Conversion.MetalGlossChannelSwap:
+					return SetConversionMaterialSettings(_metalGlossChannelSwapMaterial, textureMapType);
+				case TextureExportSettings.Conversion.MetalGlossOcclusionChannelSwap:
 					return SetConversionMaterialSettings(_metalGlossOcclusionChannelSwapMaterial, textureMapType);
 				default:
 					return null;
 			}
 		}
 
-        private static Material SetConversionMaterialSettings(Material material, TextureExportSettings textureMapType)
-        {
-            if (material && material.HasProperty("_SmoothnessRangeMin"))
-                material.SetFloat("_SmoothnessRangeMin", textureMapType.smoothnessRangeMin);
-            if (material && material.HasProperty("_SmoothnessRangeMax"))
-                material.SetFloat("_SmoothnessRangeMax", textureMapType.smoothnessRangeMax);
+		private static Material SetConversionMaterialSettings(Material material, TextureExportSettings textureMapType)
+		{
+			if (material && material.HasProperty("_SmoothnessRangeMin"))
+				material.SetFloat("_SmoothnessRangeMin", textureMapType.smoothnessRangeMin);
+			if (material && material.HasProperty("_SmoothnessRangeMax"))
+				material.SetFloat("_SmoothnessRangeMax", textureMapType.smoothnessRangeMax);
 
-            if (material && material.HasProperty("_MetallicRangeMin"))
-                material.SetFloat("_MetallicRangeMin", textureMapType.metallicRangeMin);
-            if (material && material.HasProperty("_MetallicRangeMax"))
-                material.SetFloat("_MetallicRangeMax", textureMapType.metallicRangeMax);
+			if (material && material.HasProperty("_MetallicRangeMin"))
+				material.SetFloat("_MetallicRangeMin", textureMapType.metallicRangeMin);
+			if (material && material.HasProperty("_MetallicRangeMax"))
+				material.SetFloat("_MetallicRangeMax", textureMapType.metallicRangeMax);
 
-            if (material && material.HasProperty("_OcclusionRangeMin"))
-                material.SetFloat("_OcclusionRangeMin", textureMapType.occlusionRangeMin);
-            if (material && material.HasProperty("_OcclusionRangeMax"))
-                material.SetFloat("_OcclusionRangeMax", textureMapType.occlusionRangeMax);
+			if (material && material.HasProperty("_OcclusionRangeMin"))
+				material.SetFloat("_OcclusionRangeMin", textureMapType.occlusionRangeMin);
+			if (material && material.HasProperty("_OcclusionRangeMax"))
+				material.SetFloat("_OcclusionRangeMax", textureMapType.occlusionRangeMax);
 
-            return material;
-        }
+			return material;
+		}
 
-        private struct ImageInfo
+		private struct ImageInfo
 		{
 			public Texture2D texture;
 			public TextureExportSettings textureMapType;

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -324,9 +324,13 @@ namespace UnityGLTF
                 material.DoubleSided = true;
             }
 
-			if (materialObj.HasProperty("_OcclusionMap") || materialObj.HasProperty("occlusionTexture") || materialObj.HasProperty("_OcclusionTexture"))
+			if (materialObj.HasProperty("_OcclusionMap") || materialObj.HasProperty("occlusionTexture") || materialObj.HasProperty("_OcclusionTexture") || materialObj.HasProperty("_MaskMap"))
 			{
-				var propName = materialObj.HasProperty("occlusionTexture") ? "occlusionTexture" : materialObj.HasProperty("_OcclusionTexture") ? "_OcclusionTexture" : "_OcclusionMap";
+				var propName = materialObj.HasProperty("occlusionTexture") ? "occlusionTexture" :
+					materialObj.HasProperty("_OcclusionTexture") ? "_OcclusionTexture" :
+					materialObj.HasProperty("_MaskMap") ? "_MaskMap" :
+					"_OcclusionMap";
+
 				var occTex = materialObj.GetTexture(propName);
 				if (occTex)
 				{
@@ -817,14 +821,19 @@ namespace UnityGLTF
                 {
 					// bake remapping into texture during export
                     var conversion = GetExportSettingsForSlot(TextureMapType.MetallicGloss);
-                    conversion.metallicRangeMax = material.GetFloat("_MetallicRemapMax");
-                    conversion.metallicRangeMin = material.GetFloat("_MetallicRemapMin");
-                    conversion.smoothnessRangeMax = material.GetFloat("_SmoothnessRemapMax");
-					conversion.smoothnessRangeMin = material.GetFloat("_SmoothnessRemapMin");
-					conversion.conversion = TextureExportSettings.Conversion.MetalGlossChannelSwap;
 
-					// set factors to 1 because of baked values
-					pbr.MetallicFactor = 1f;
+                    conversion.metallicRangeMin = material.GetFloat("_MetallicRemapMin");
+                    conversion.metallicRangeMax = material.GetFloat("_MetallicRemapMax");
+					conversion.smoothnessRangeMin = material.GetFloat("_SmoothnessRemapMin");
+                    conversion.smoothnessRangeMax = material.GetFloat("_SmoothnessRemapMax");
+					conversion.occlusionRangeMin = material.GetFloat("_AORemapMin");
+					conversion.occlusionRangeMax = material.GetFloat("_AORemapMax");
+                    
+					conversion.conversion = TextureExportSettings.Conversion.MetalGlossOcclusionChannelSwap;
+					_occlusionBakedTextures.Add(material);
+
+                    // set factors to 1 because of baked values
+                    pbr.MetallicFactor = 1f;
 					pbr.RoughnessFactor = 1f;
 
                     pbr.MetallicRoughnessTexture = ExportTextureInfo(mrTex, TextureMapType.MetallicRoughness, conversion);

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -176,8 +176,7 @@ namespace UnityGLTF
 					}
 					else
 					{
-						var c =
-							materialObj.HasProperty("_EmissionColor") ? materialObj.GetColor("_EmissionColor") :
+						var c = materialObj.HasProperty("_EmissionColor") ? materialObj.GetColor("_EmissionColor") :
 							materialObj.HasProperty("emissiveFactor") ? materialObj.GetColor("emissiveFactor") :
 							materialObj.GetColor("_EmissiveFactor");
 						DecomposeEmissionColor(c, out emissiveAmount, out maxEmissiveAmount);

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -390,7 +390,8 @@ namespace UnityGLTF
 	        return (material.HasProperty("_Metallic") || material.HasProperty("_MetallicFactor") || material.HasProperty("metallicFactor")) &&
 	               (material.HasProperty("_MetallicGlossMap") || material.HasProperty("_Glossiness") ||
 	                material.HasProperty("_Roughness") || material.HasProperty("_RoughnessFactor") || material.HasProperty("roughnessFactor") ||
-	                material.HasProperty("_MetallicRoughnessTexture") || material.HasProperty("metallicRoughnessTexture"));
+					material.HasProperty("_MetallicRoughnessTexture") || material.HasProperty("metallicRoughnessTexture") ||
+					material.HasProperty("_Smoothness"));
         }
 
         private bool IsUnlit(Material material)

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -792,7 +792,7 @@ namespace UnityGLTF
 					if (needToBakeRoughnessIntoTexture)
 					{
 						conversion = new TextureExportSettings(conversion);
-						conversion.smoothnessMultiplier = 1 - roughnessMultiplier;
+						conversion.smoothnessRangeMax = 1 - roughnessMultiplier;
 					}
 					
 					if (occlusionGetBakedIntoMetallicRoughness)
@@ -817,10 +817,10 @@ namespace UnityGLTF
                 {
 					// bake remapping into texture during export
                     var conversion = GetExportSettingsForSlot(TextureMapType.MetallicGloss);
-                    conversion.metallicMultiplier = material.GetFloat("_MetallicRemapMax");
-                    conversion.metallicMultiplier2 = material.GetFloat("_MetallicRemapMin");
-                    conversion.smoothnessMultiplier = material.GetFloat("_SmoothnessRemapMax");
-					conversion.smoothnessMultiplier2 = material.GetFloat("_SmoothnessRemapMin");
+                    conversion.metallicRangeMax = material.GetFloat("_MetallicRemapMax");
+                    conversion.metallicRangeMin = material.GetFloat("_MetallicRemapMin");
+                    conversion.smoothnessRangeMax = material.GetFloat("_SmoothnessRemapMax");
+					conversion.smoothnessRangeMin = material.GetFloat("_SmoothnessRemapMin");
 					conversion.conversion = TextureExportSettings.Conversion.MetalGlossChannelSwap;
 
 					// set factors to 1 because of baked values

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -212,26 +212,6 @@ namespace UnityGLTF
 
 					if (emissionTex)
 					{
-						UnityEngine.Debug.Log(emissionTex.ToString(), emissionTex);
-						UnityEngine.Debug.Log(materialObj.ToString(), materialObj);
-						//// emissive color is not used for hdrp lit materials when map is set, we have to look at the intensity :o
-						//if(materialObj.HasProperty("_EmissiveColorMap") && materialObj.HasProperty("_EmissiveIntensity"))
-						//{
-      //                      //var ei = materialObj.GetFloat("_EmissiveIntensity");
-      //                      //material.EmissiveFactor = new GLTF.Math.Color(ei, ei, ei, 1f);
-
-						//	// for now, lets just default to white and remove the extension if it was applied
-						//	material.EmissiveFactor = GLTF.Math.Color.White;
-
-      //                      var materialSettings = (_plugins.FirstOrDefault(x => x is MaterialExtensionsExportContext) as MaterialExtensionsExportContext)?.settings;
-      //                      var emissiveStrengthSupported = materialSettings && materialSettings.KHR_materials_emissive_strength;
-      //                      if (emissiveStrengthSupported && material.Extensions != null)
-      //                      {
-						//		// remove the old entry
-						//		material.Extensions.Remove(KHR_materials_emissive_strength_Factory.EXTENSION_NAME);
-      //                      }
-      //                  }
-
 						if(emissionTex is Texture2D)
 						{
 							material.EmissiveTexture = ExportTextureInfo(emissionTex, TextureMapType.Emissive);

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -809,6 +809,29 @@ namespace UnityGLTF
 					ExportTextureTransform(pbr.MetallicRoughnessTexture, material, "_MetallicGlossMap");
 				}
 			}
+			else if(material.HasProperty("_MaskMap"))
+			{
+                var mrTex = material.GetTexture("_MaskMap");
+
+                if (mrTex)
+                {
+					// bake remapping into texture during export
+                    var conversion = GetExportSettingsForSlot(TextureMapType.MetallicGloss);
+                    conversion.metallicMultiplier = material.GetFloat("_MetallicRemapMax");
+                    conversion.metallicMultiplier2 = material.GetFloat("_MetallicRemapMin");
+                    conversion.smoothnessMultiplier = material.GetFloat("_SmoothnessRemapMax");
+					conversion.smoothnessMultiplier2 = material.GetFloat("_SmoothnessRemapMin");
+					conversion.conversion = TextureExportSettings.Conversion.MetalGlossChannelSwap;
+
+					// set factors to 1 because of baked values
+					pbr.MetallicFactor = 1f;
+					pbr.RoughnessFactor = 1f;
+
+                    pbr.MetallicRoughnessTexture = ExportTextureInfo(mrTex, TextureMapType.MetallicRoughness, conversion);
+
+                    ExportTextureTransform(pbr.MetallicRoughnessTexture, material, "_MaskMap");
+                }
+            }
 
 			return pbr;
 		}

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -238,6 +238,25 @@ namespace UnityGLTF
 				}
 			}
 
+			if (materialObj.HasProperty("_NormalMap"))
+			{
+				var propName = "_NormalMap";
+				var normalTex = materialObj.GetTexture(propName);
+
+				if (normalTex)
+				{
+					if (normalTex is Texture2D)
+					{
+						material.NormalTexture = ExportNormalTextureInfo(normalTex, TextureMapType.Normal, materialObj);
+						ExportTextureTransform(material.NormalTexture, materialObj, propName);
+					}
+					else
+					{
+						Debug.LogFormat(LogType.Error, "Can't export a {0} normal texture in material {1}", normalTex.GetType(), materialObj.name);
+					}
+				}
+			}
+
 			if (IsUnlit(materialObj))
 			{
 				ExportUnlit( material, materialObj );

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -165,8 +165,8 @@ namespace UnityGLTF
 						// hdrp route uses its own color decomposition
 						if (materialObj.GetFloat("_UseEmissiveIntensity") == 1)
 						{
-                            emissiveAmount = materialObj.GetColor("_EmissiveColorLDR");
-                            maxEmissiveAmount = materialObj.GetFloat("_EmissiveIntensity");
+							emissiveAmount = materialObj.GetColor("_EmissiveColorLDR");
+							maxEmissiveAmount = materialObj.GetFloat("_EmissiveIntensity");
 						}
 						else
 						{
@@ -182,7 +182,7 @@ namespace UnityGLTF
 							materialObj.GetColor("_EmissiveFactor");
 						DecomposeEmissionColor(c, out emissiveAmount, out maxEmissiveAmount);
 					}
-
+					
 					if (isUnityMaterialWithWeirdColorspaceHandling)
 						material.EmissiveFactor = emissiveAmount.ToNumericsColorRaw();
 					else
@@ -205,8 +205,8 @@ namespace UnityGLTF
 					var propName = materialObj.HasProperty("emissiveTexture") ? "emissiveTexture" :
 						materialObj.HasProperty("_EmissiveTexture") ? "_EmissiveTexture" :
 						materialObj.HasProperty("_EmissionMap") ? "_EmissionMap" :
-                        materialObj.HasProperty("_EmissiveColorMap") ? "_EmissiveColorMap" :
-                        "_EmissiveMap";
+						materialObj.HasProperty("_EmissiveColorMap") ? "_EmissiveColorMap" :
+						"_EmissiveMap";
 
 					var emissionTex = materialObj.GetTexture(propName);
 
@@ -842,32 +842,32 @@ namespace UnityGLTF
 			}
 			else if(material.HasProperty("_MaskMap"))
 			{
-                var mrTex = material.GetTexture("_MaskMap");
+				var mrTex = material.GetTexture("_MaskMap");
 
-                if (mrTex)
-                {
+				if (mrTex)
+				{
 					// bake remapping into texture during export
-                    var conversion = GetExportSettingsForSlot(TextureMapType.MetallicGloss);
+					var conversion = GetExportSettingsForSlot(TextureMapType.MetallicGloss);
 
-                    conversion.metallicRangeMin = material.GetFloat("_MetallicRemapMin");
-                    conversion.metallicRangeMax = material.GetFloat("_MetallicRemapMax");
+					conversion.metallicRangeMin = material.GetFloat("_MetallicRemapMin");
+					conversion.metallicRangeMax = material.GetFloat("_MetallicRemapMax");
 					conversion.smoothnessRangeMin = material.GetFloat("_SmoothnessRemapMin");
-                    conversion.smoothnessRangeMax = material.GetFloat("_SmoothnessRemapMax");
+					conversion.smoothnessRangeMax = material.GetFloat("_SmoothnessRemapMax");
 					conversion.occlusionRangeMin = material.GetFloat("_AORemapMin");
 					conversion.occlusionRangeMax = material.GetFloat("_AORemapMax");
-                    
+					
 					conversion.conversion = TextureExportSettings.Conversion.MetalGlossOcclusionChannelSwap;
 					_occlusionBakedTextures.Add(material);
 
-                    // set factors to 1 because of baked values
-                    pbr.MetallicFactor = 1f;
+					// set factors to 1 because of baked values
+					pbr.MetallicFactor = 1f;
 					pbr.RoughnessFactor = 1f;
 
-                    pbr.MetallicRoughnessTexture = ExportTextureInfo(mrTex, TextureMapType.MetallicRoughness, conversion);
+					pbr.MetallicRoughnessTexture = ExportTextureInfo(mrTex, TextureMapType.MetallicRoughness, conversion);
 
-                    ExportTextureTransform(pbr.MetallicRoughnessTexture, material, "_MaskMap");
-                }
-            }
+					ExportTextureTransform(pbr.MetallicRoughnessTexture, material, "_MaskMap");
+				}
+			}
 
 			return pbr;
 		}
@@ -1098,29 +1098,29 @@ namespace UnityGLTF
 			return _textures[textureIndex].Texture;
 		}
 
-        // from HDRP's HDUtils.ConvertHDRColorToLDR
-        internal static void ConvertHDRColorToLDR(Color hdr, out Color ldr, out float intensity)
-        {
-            // specifies the max byte value to use when decomposing a float color into bytes with exposure
-            // this is the value used by Photoshop
-            const float k_MaxByteForOverexposedColor = 191;
+		// from HDRP's HDUtils.ConvertHDRColorToLDR
+		internal static void ConvertHDRColorToLDR(Color hdr, out Color ldr, out float intensity)
+		{
+			// specifies the max byte value to use when decomposing a float color into bytes with exposure
+			// this is the value used by Photoshop
+			const float k_MaxByteForOverexposedColor = 191;
 
-            hdr.a = 1.0f;
-            ldr = hdr;
-            intensity = 1.0f;
+			hdr.a = 1.0f;
+			ldr = hdr;
+			intensity = 1.0f;
 
-            var maxColorComponent = hdr.maxColorComponent;
-            if (maxColorComponent != 0f)
-            {
-                // calibrate exposure to the max float color component
-                var scaleFactor = k_MaxByteForOverexposedColor / maxColorComponent;
+			var maxColorComponent = hdr.maxColorComponent;
+			if (maxColorComponent != 0f)
+			{
+				// calibrate exposure to the max float color component
+				var scaleFactor = k_MaxByteForOverexposedColor / maxColorComponent;
 
-                ldr.r = Mathf.Min(k_MaxByteForOverexposedColor, scaleFactor * hdr.r) / 255f;
-                ldr.g = Mathf.Min(k_MaxByteForOverexposedColor, scaleFactor * hdr.g) / 255f;
-                ldr.b = Mathf.Min(k_MaxByteForOverexposedColor, scaleFactor * hdr.b) / 255f;
+				ldr.r = Mathf.Min(k_MaxByteForOverexposedColor, scaleFactor * hdr.r) / 255f;
+				ldr.g = Mathf.Min(k_MaxByteForOverexposedColor, scaleFactor * hdr.g) / 255f;
+				ldr.b = Mathf.Min(k_MaxByteForOverexposedColor, scaleFactor * hdr.b) / 255f;
 
-                intensity = 255f / scaleFactor;
-            }
-        }
-    }
+				intensity = 255f / scaleFactor;
+			}
+		}
+	}
 }

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -207,7 +207,7 @@ namespace UnityGLTF
 
                             var materialSettings = (_plugins.FirstOrDefault(x => x is MaterialExtensionsExportContext) as MaterialExtensionsExportContext)?.settings;
                             var emissiveStrengthSupported = materialSettings && materialSettings.KHR_materials_emissive_strength;
-                            if (emissiveStrengthSupported)
+                            if (emissiveStrengthSupported && material.Extensions != null)
                             {
 								// remove the old entry
 								material.Extensions.Remove(KHR_materials_emissive_strength_Factory.EXTENSION_NAME);


### PR DESCRIPTION
This adds basic export support for some of HDRP's standard shaders:
- Normal map 
- Metallic/smoothness via scalars or mask map
- Occlusion via mask map
- Emission via HDR and LDR+intensity workflows and emission map

To support the remapping of the mask map values, the channel swap shaders now support min/max values per used channel.
`smoothnessMultiplier` is now `smoothnessRangeMax` and `smoothnessRangeMin` has a default value of 0. Newly introduced min/max ranges also default to 0/1. This way, it should work exactly like before for material exports not using the ranges.

There's much to be desired for full support, even in the added functionality: UV sets, multiplicative emission, emission exposure weight come to mind. But for my use cases it works just fine and produces good looking results.