### PR TITLE
Improve export menu with multi-object export, multi-scene export, more control

### DIFF
--- a/Editor/Scripts/GLTFExportMenu.cs
+++ b/Editor/Scripts/GLTFExportMenu.cs
@@ -1,13 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditor.ProjectWindowCallback;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.Serialization;
 using Object = UnityEngine.Object;
 
 namespace UnityGLTF
@@ -17,8 +18,8 @@ namespace UnityGLTF
 		private const string MenuPrefix = "Assets/UnityGLTF/";
 		private const string MenuPrefixGameObject = "GameObject/UnityGLTF/";
 
-		private const string ExportGltf = "Export selected as glTF";
-		private const string ExportGlb = "Export selected as GLB";
+		private const string ExportGlb = "Export selected as one asset";
+		private const string ExportGlbBatch = "Export each as separate asset";
 
 	    public static string RetrieveTexturePath(UnityEngine.Texture texture)
 	    {
@@ -26,13 +27,20 @@ namespace UnityGLTF
 	        // texture is a subasset
 	        if (AssetDatabase.GetMainAssetTypeAtPath(path) != typeof(Texture2D))
 	        {
-		        var ext = System.IO.Path.GetExtension(path);
+		        var ext = Path.GetExtension(path);
 		        if (string.IsNullOrWhiteSpace(ext)) return texture.name + ".png";
 		        path = path.Replace(ext, "-" + texture.name + ext);
 	        }
 	        return path;
 	    }
 
+	    /// <summary>
+	    /// This method collects GameObjects into export jobs. It supports multi-selection exports in various useful ways.
+	    /// 1. When multiple scene objects are selected, they are exported together as one file.
+	    /// 2. When multiple prefabs are selected, each one is exported as individual file.
+	    /// 3. When multiple scenes are selected, each scene is exported as individual file.
+	    /// </summary>
+	    /// <returns>True if the current selection can be exported.</returns>
 	    private static bool TryGetExportNameAndRootTransformsFromSelection(out string sceneName, out Transform[] rootTransforms, out Object[] rootResources, bool openSceneIfNeeded)
 	    {
 		    if (Selection.transforms.Length > 1)
@@ -70,15 +78,14 @@ namespace UnityGLTF
 			    sceneName = Selection.objects.First().name;
 			    if (openSceneIfNeeded)
 			    {
-				    if (EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
-				    {
-					    var scenePath = AssetDatabase.GetAssetPath(Selection.objects.First());
-					    var scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
-					    var roots = scene.GetRootGameObjects();
-					    rootTransforms = Array.ConvertAll(roots, x => x.transform);
-					    rootResources = null;
-					    return true;
-				    }
+				    var firstScene = (SceneAsset) Selection.objects.First();
+				    var stage = ScriptableObject.CreateInstance<ExportStage>();
+				    stage.Setup(AssetDatabase.GetAssetPath(firstScene));
+				    StageUtility.GoToStage(stage, true);
+				    var roots = stage.scene.GetRootGameObjects();
+				    rootTransforms = Array.ConvertAll(roots, x => x.transform);
+				    rootResources = null;
+				    return true;
 			    }
 			    rootTransforms = null;
 			    rootResources = null;
@@ -91,40 +98,42 @@ namespace UnityGLTF
 		    return false;
 	    }
 
-	    [MenuItem(MenuPrefix + ExportGltf, true)]
-	    [MenuItem(MenuPrefixGameObject + ExportGltf, true)]
-	    private static bool ExportSelectedValidate()
+	    private class ExportStage: PreviewSceneStage
 	    {
-		    return TryGetExportNameAndRootTransformsFromSelection(out _, out _, out _, false);
+		    private static MethodInfo _openPreviewScene;
+
+		    protected override bool OnOpenStage() => true;
+
+		    public void Setup(string scenePath)
+		    {
+#if !UNITY_2023_1_OR_NEWER
+			    if (_openPreviewScene == null) _openPreviewScene = typeof(EditorSceneManager).GetMethod("OpenPreviewScene", (BindingFlags)(-1), null, new[] {typeof(string), typeof(bool)}, null);
+			    if (_openPreviewScene == null) return;
+			    
+			    scene = (Scene) _openPreviewScene.Invoke(null, new object[] { scenePath, false });
+#else
+			    scene = EditorSceneManager.OpenPreviewScene(scenePath, false);
+#endif
+		    }
+		    
+		    protected override GUIContent CreateHeaderContent()
+		    {
+			    return new GUIContent("Export: " + scene.name);
+		    }
 	    }
+	    
+	    private static bool ExportBinary => !SessionState.GetBool(ExportAsBinary, false);
 
-	    [MenuItem(MenuPrefix + ExportGltf)]
-	    [MenuItem(MenuPrefixGameObject + ExportGltf, false, 33)]
-	    private static void ExportSelected(MenuCommand command)
-		{
-			// The exporter handles multi-selection. We don't want to call export multiple times here.
-			if (Selection.gameObjects.Length > 1 && command.context != Selection.gameObjects[0])
-				return;
-			
-			if (!TryGetExportNameAndRootTransformsFromSelection(out var sceneName, out var rootTransforms, out var rootResources, true))
-			{
-				Debug.LogError("Can't export: selection is empty");
-				return;
-			}
-
-			Export(rootTransforms, rootResources, false, sceneName);
-		}
-
-		[MenuItem(MenuPrefix + ExportGlb, true)]
+		[MenuItem(MenuPrefix + ExportGlb + " &SPACE", true)]
 		[MenuItem(MenuPrefixGameObject + ExportGlb, true)]
-		private static bool ExportGLBSelectedValidate()
+		private static bool ExportSelectedValidate()
 		{
 			return TryGetExportNameAndRootTransformsFromSelection(out _, out _, out _, false);
 		}
 
-		[MenuItem(MenuPrefix + ExportGlb)]
+		[MenuItem(MenuPrefix + ExportGlb + " &SPACE")]
 		[MenuItem(MenuPrefixGameObject + ExportGlb, false, 34)]
-		private static void ExportGLBSelected(MenuCommand command)
+		private static void ExportSelected(MenuCommand command)
 		{
 			// The exporter handles multi-selection. We don't want to call export multiple times here.
 			if (Selection.gameObjects.Length > 1 && command.context != Selection.gameObjects[0] && !(Selection.activeObject is SceneAsset))
@@ -135,27 +144,76 @@ namespace UnityGLTF
 				Debug.LogError("Can't export: selection is empty");
 				return;
 			}
-			Export(rootTransforms, rootResources, true, sceneName);
+			Export(rootTransforms, rootResources, ExportBinary, sceneName);
+		}
+		
+		[MenuItem(MenuPrefix + ExportGlbBatch, true)]
+		[MenuItem(MenuPrefixGameObject + ExportGlbBatch, true)]
+		private static bool ExportSelectedBatchValidate()
+		{
+			return TryGetExportNameAndRootTransformsFromSelection(out _, out _, out _, false);
+		}
+		
+		[MenuItem(MenuPrefix + ExportGlbBatch)]
+		[MenuItem(MenuPrefixGameObject + ExportGlbBatch, false, 34)]
+		private static void ExportSelectedBatch(MenuCommand command)
+		{
+			// The exporter handles multi-selection. We don't want to call export multiple times here.
+			if (Selection.gameObjects.Length > 1 && command.context != Selection.gameObjects[0] && !(Selection.activeObject is SceneAsset))
+				return;
+			
+			if (!TryGetExportNameAndRootTransformsFromSelection(out var sceneName, out var rootTransforms, out var rootResources, true))
+			{
+				Debug.LogError("Can't export: selection is empty");
+				return;
+			}
+			Export(rootTransforms, rootResources, ExportBinary, sceneName);
 		}
 
-		[MenuItem(MenuPrefix + "Export active scene as glTF")]
+		[MenuItem(MenuPrefix + "Export active scene", true)]
+		private static bool ExportSceneValidate()
+		{
+			var activeScene = SceneManager.GetActiveScene();
+			if (!activeScene.IsValid()) return false;
+			return true;
+		}
+		
+		[MenuItem(MenuPrefix + "Export active scene")]
 		private static void ExportScene()
 		{
 			var scene = SceneManager.GetActiveScene();
+			ExportScene(scene);
+		}
+		
+		private static void ExportScene(Scene scene)
+		{
 			var gameObjects = scene.GetRootGameObjects();
 			var transforms = Array.ConvertAll(gameObjects, gameObject => gameObject.transform);
 
-			Export(transforms, null, false, scene.name);
+			Export(transforms, null, ExportBinary, scene.name);
 		}
 
-		[MenuItem(MenuPrefix + "Export active scene as GLB")]
-		private static void ExportSceneGLB()
+		private static void ExportAllScenes()
 		{
-			var scene = SceneManager.GetActiveScene();
-			var gameObjects = scene.GetRootGameObjects();
-			var transforms = Array.ConvertAll(gameObjects, gameObject => gameObject.transform);
+			var roots = new List<Transform>();
+			for (var i = 0; i < SceneManager.sceneCount; i++)
+			{
+				var scene = SceneManager.GetSceneAt(i);
+				if (!scene.IsValid()) continue;
+				roots.AddRange(Array.ConvertAll(scene.GetRootGameObjects(), gameObject => gameObject.transform));
+			}
+			Export(roots.ToArray(), null, ExportBinary, SceneManager.GetActiveScene().name);
+		}
 
-			Export(transforms, null, true, scene.name);
+		private static void ExportAllScenesBatch()
+		{
+			for (var i = 0; i < SceneManager.sceneCount; i++)
+			{
+				var scene = SceneManager.GetSceneAt(i);
+				if (!scene.IsValid()) continue;
+				var roots = Array.ConvertAll(scene.GetRootGameObjects(), gameObject => gameObject.transform);
+				Export(roots, null, ExportBinary, scene.name);
+			}
 		}
 
 		private static void Export(Transform[] transforms, Object[] resources, bool binary, string sceneName)
@@ -199,6 +257,61 @@ namespace UnityGLTF
 				Debug.Log("Exported to " + resultFile);
 				EditorUtility.RevealInFinder(resultFile);
 			}
+		}
+		
+		const string SettingsMenu = "Open Export Settings";
+		[MenuItem(MenuPrefixGameObject + SettingsMenu, true, 3000)]
+		private static bool ShowSettingsValidate()
+		{
+			return TryGetExportNameAndRootTransformsFromSelection(out _, out _, out _, false);
+		}
+
+		[InitializeOnLoadMethod]
+		private static void Hooks()
+		{
+			SceneHierarchyHooks.addItemsToSceneHeaderContextMenu += (menu, scene) =>
+			{
+				menu.AddItem(new GUIContent("UnityGLTF/Export selected scene"), false, () => ExportScene(scene));
+			};
+			
+			SceneHierarchyHooks.addItemsToGameObjectContextMenu += (menu, gameObject) =>
+			{
+				if (gameObject)
+				{
+					var current = SessionState.GetBool(ExportAsBinary, false);
+					menu.AddItem(new GUIContent("UnityGLTF/Export as binary (GLB)"), !current, () =>
+					{
+						current = !current;
+						SessionState.SetBool(ExportAsBinary, current);
+					});
+				}
+				else
+				{
+					menu.AddItem(new GUIContent("UnityGLTF/Export active scene"), false, ExportScene);
+					if (SceneManager.loadedSceneCount > 1)
+					{
+						menu.AddItem(new GUIContent("UnityGLTF/Export all scenes as one asset"), false, ExportAllScenes);
+						menu.AddItem(new GUIContent("UnityGLTF/Export each scene as separate asset"), false, ExportAllScenesBatch);
+					}
+				}
+			};
+		} 
+		
+		[MenuItem(MenuPrefix + SettingsMenu, false, 3000)]
+		[MenuItem(MenuPrefixGameObject + SettingsMenu, false, 3000)]
+		private static void ShowSettings()
+		{
+			SettingsService.OpenProjectSettings("Project/UnityGLTF");
+		}
+		
+		const string ExportAsBinary = MenuPrefix + "Export as binary (GLB)";
+		[MenuItem(ExportAsBinary, false, 3001)]
+		private static void ToggleExportAsGltf()
+		{
+			var current = SessionState.GetBool(ExportAsBinary, true);
+			current = !current;
+			SessionState.SetBool(ExportAsBinary, current);
+			Menu.SetChecked(ExportAsBinary, current);
 		}
 	}
 


### PR DESCRIPTION
Previously, not all cases of selecting multiple objects and exporting them were supported. Additionally, it didn't really make sense to export selections of e.g. Prefabs as a single GLB, since the intent was likely exporting multiple files.

This PR refurbishes the export menu and adds explicit options to export the selection as one single file or as multiple files.
Addtionally, scene assets can now be selected and exported.

Future work might include better options for resetting root transforms – currently selected transforms are exported in _parent space_ which can be unexpected when multiple objects with different parents are selected (without their parents also being selected).