### PR TITLE
Add transform modes for single-object and batch export

### DIFF
--- a/Editor/Scripts/GLTFExportMenu.cs
+++ b/Editor/Scripts/GLTFExportMenu.cs
@@ -75,7 +75,7 @@ namespace UnityGLTF
 			    // Adjust local position
 			    // - easy case for now: set to 0
 			    // - better heuristic might be: if current local position in any axis fits into the bounds: keep that axis; if it doesn't fit into the bounds: set to 0
-			    case GLTFSettings.TransformMode.AutoTransforms:
+			    case GLTFSettings.TransformMode.Auto:
 				    return new TransformData
 				    {
 					    position = Vector3.zero, 
@@ -281,7 +281,7 @@ namespace UnityGLTF
 		    }
 	    }
 	    
-	    private static bool ExportBinary => settings.EditorExportsFileFormat == GLTFSettings.ExportFileFormat.Glb;
+	    private static bool ExportBinary => settings.EditorExportFileFormat == GLTFSettings.ExportFileFormat.Glb;
 	    private const int Priority = 34;
 
 		[MenuItem(MenuPrefix + ExportGlb + " &SPACE", true, Priority)]
@@ -546,11 +546,11 @@ namespace UnityGLTF
 			{
 				if (gameObject)
 				{
-					var current = settings.EditorExportsFileFormat == GLTFSettings.ExportFileFormat.Glb;
+					var current = settings.EditorExportFileFormat == GLTFSettings.ExportFileFormat.Glb;
 					menu.AddItem(new GUIContent("UnityGLTF/Export as binary (GLB)"), current, () =>
 					{
 						current = !current;
-						settings.EditorExportsFileFormat = current ? GLTFSettings.ExportFileFormat.Glb : GLTFSettings.ExportFileFormat.Gltf;
+						settings.EditorExportFileFormat = current ? GLTFSettings.ExportFileFormat.Glb : GLTFSettings.ExportFileFormat.Gltf;
 					});
 				}
 				else
@@ -576,9 +576,9 @@ namespace UnityGLTF
 		[MenuItem(ExportAsBinary, false, 3001)]
 		private static void ToggleExportAsGltf()
 		{
-			var current = settings.EditorExportsFileFormat == GLTFSettings.ExportFileFormat.Glb;
+			var current = settings.EditorExportFileFormat == GLTFSettings.ExportFileFormat.Glb;
 			current = !current;
-			settings.EditorExportsFileFormat = current ? GLTFSettings.ExportFileFormat.Glb : GLTFSettings.ExportFileFormat.Gltf;
+			settings.EditorExportFileFormat = current ? GLTFSettings.ExportFileFormat.Glb : GLTFSettings.ExportFileFormat.Gltf;
 			Menu.SetChecked(ExportAsBinary, current);
 		}
 	}

--- a/Editor/Scripts/GLTFExportMenu.cs
+++ b/Editor/Scripts/GLTFExportMenu.cs
@@ -281,7 +281,7 @@ namespace UnityGLTF
 		    }
 	    }
 	    
-	    private static bool ExportBinary => settings.EditorExportsAsBinary;
+	    private static bool ExportBinary => settings.EditorExportsFileFormat == GLTFSettings.ExportFileFormat.Glb;
 	    private const int Priority = 34;
 
 		[MenuItem(MenuPrefix + ExportGlb + " &SPACE", true, Priority)]
@@ -546,11 +546,11 @@ namespace UnityGLTF
 			{
 				if (gameObject)
 				{
-					var current = settings.EditorExportsAsBinary;
+					var current = settings.EditorExportsFileFormat == GLTFSettings.ExportFileFormat.Glb;
 					menu.AddItem(new GUIContent("UnityGLTF/Export as binary (GLB)"), current, () =>
 					{
 						current = !current;
-						settings.EditorExportsAsBinary = current;
+						settings.EditorExportsFileFormat = current ? GLTFSettings.ExportFileFormat.Glb : GLTFSettings.ExportFileFormat.Gltf;
 					});
 				}
 				else
@@ -576,9 +576,9 @@ namespace UnityGLTF
 		[MenuItem(ExportAsBinary, false, 3001)]
 		private static void ToggleExportAsGltf()
 		{
-			var current = settings.EditorExportsAsBinary;
+			var current = settings.EditorExportsFileFormat == GLTFSettings.ExportFileFormat.Glb;
 			current = !current;
-			settings.EditorExportsAsBinary = current;
+			settings.EditorExportsFileFormat = current ? GLTFSettings.ExportFileFormat.Glb : GLTFSettings.ExportFileFormat.Gltf;
 			Menu.SetChecked(ExportAsBinary, current);
 		}
 	}

--- a/Editor/Scripts/GLTFExportMenu.cs
+++ b/Editor/Scripts/GLTFExportMenu.cs
@@ -50,22 +50,10 @@ namespace UnityGLTF
 		    public Vector3 scale;
 	    }
 
-	    enum TransformMode
-	    {
-		    /** Reset local position, keep local rotation, keep world scale. This is a heuristic for exporting objects from anywhere in the scene for general usage. */
-		    AutoTransforms,
-		    /** Keep local position, rotation, and scale. This is useful if you want to export childs of hierarchies and import them again as childs. */
-		    LocalTransforms,
-		    /** Keep world position, rotation, and scale. This is useful for exporting parts of scenes and keeping all relations between objects the same. */
-		    WorldTransforms,
-	    }
-
-	    // TODO this should come from settings
-	    private static TransformMode transformMode = TransformMode.WorldTransforms;
-
 	    private static TransformData? GetOverride(Transform transform)
 	    {
-		    switch (transformMode)
+		    var settings = GLTFSettings.GetOrCreateSettings();
+		    switch (settings.EditorExportTransformMode)
 		    {
 			    // Heuristic for correcting the placement of the object in the scene
 			    // Keep world scale
@@ -75,14 +63,14 @@ namespace UnityGLTF
 			    // Adjust local position
 			    // - easy case for now: set to 0
 			    // - better heuristic might be: if current local position in any axis fits into the bounds: keep that axis; if it doesn't fit into the bounds: set to 0
-			    case TransformMode.AutoTransforms:
+			    case GLTFSettings.TransformMode.AutoTransforms:
 				    return new TransformData
 				    {
 					    position = Vector3.zero, 
 					    rotation = transform.localRotation, 
 					    scale = transform.lossyScale
 				    };
-			    case TransformMode.WorldTransforms:
+			    case GLTFSettings.TransformMode.WorldTransforms:
 				    return new TransformData
 				    {
 					    position = transform.position, 
@@ -90,7 +78,7 @@ namespace UnityGLTF
 					    scale = transform.lossyScale
 				    };
 			    // This is the built-in case for GLTFExporter: it exports the local transforms of nodes into glTF.
-			    case TransformMode.LocalTransforms:
+			    case GLTFSettings.TransformMode.LocalTransforms:
 			    default:
 				    return null;
 		    }

--- a/Editor/Scripts/GLTFExportMenu.cs
+++ b/Editor/Scripts/GLTFExportMenu.cs
@@ -269,7 +269,7 @@ namespace UnityGLTF
 		    }
 	    }
 	    
-	    private static bool ExportBinary => SessionState.GetBool(ExportAsBinary, true);
+	    private static bool ExportBinary => GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary;
 	    private const int Priority = 34;
 
 		[MenuItem(MenuPrefix + ExportGlb + " &SPACE", true, Priority)]
@@ -535,11 +535,11 @@ namespace UnityGLTF
 			{
 				if (gameObject)
 				{
-					var current = SessionState.GetBool(ExportAsBinary, true);
+					var current = GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary;
 					menu.AddItem(new GUIContent("UnityGLTF/Export as binary (GLB)"), current, () =>
 					{
 						current = !current;
-						SessionState.SetBool(ExportAsBinary, current);
+						GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary = current;
 					});
 				}
 				else
@@ -565,9 +565,9 @@ namespace UnityGLTF
 		[MenuItem(ExportAsBinary, false, 3001)]
 		private static void ToggleExportAsGltf()
 		{
-			var current = SessionState.GetBool(ExportAsBinary, true);
+			var current = GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary;
 			current = !current;
-			SessionState.SetBool(ExportAsBinary, current);
+			GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary = current;
 			Menu.SetChecked(ExportAsBinary, current);
 		}
 	}

--- a/Editor/Scripts/GLTFExportMenu.cs
+++ b/Editor/Scripts/GLTFExportMenu.cs
@@ -49,10 +49,22 @@ namespace UnityGLTF
 		    public Quaternion rotation;
 		    public Vector3 scale;
 	    }
+	    
+	    private static GLTFSettings _cachedSettings;
+	    
+	    private static GLTFSettings settings
+	    { 
+		    get { 
+			    if (_cachedSettings == null)
+			    {
+				    _cachedSettings = GLTFSettings.GetOrCreateSettings();
+			    }
+			    return _cachedSettings;
+			} 
+	    }
 
 	    private static TransformData? GetOverride(Transform transform)
 	    {
-		    var settings = GLTFSettings.GetOrCreateSettings();
 		    switch (settings.EditorExportTransformMode)
 		    {
 			    // Heuristic for correcting the placement of the object in the scene
@@ -269,7 +281,7 @@ namespace UnityGLTF
 		    }
 	    }
 	    
-	    private static bool ExportBinary => GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary;
+	    private static bool ExportBinary => settings.EditorExportsAsBinary;
 	    private const int Priority = 34;
 
 		[MenuItem(MenuPrefix + ExportGlb + " &SPACE", true, Priority)]
@@ -437,7 +449,6 @@ namespace UnityGLTF
 				}
 			}
 			
-			var settings = GLTFSettings.GetOrCreateSettings();
 			var exportOptions = new ExportContext(settings) { TexturePathRetriever = RetrieveTexturePath };
 			
 			var haveOverrides = batch.rootTransformOverride != null && batch.rootTransformOverride.Length > 0;
@@ -535,11 +546,11 @@ namespace UnityGLTF
 			{
 				if (gameObject)
 				{
-					var current = GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary;
+					var current = settings.EditorExportsAsBinary;
 					menu.AddItem(new GUIContent("UnityGLTF/Export as binary (GLB)"), current, () =>
 					{
 						current = !current;
-						GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary = current;
+						settings.EditorExportsAsBinary = current;
 					});
 				}
 				else
@@ -565,9 +576,9 @@ namespace UnityGLTF
 		[MenuItem(ExportAsBinary, false, 3001)]
 		private static void ToggleExportAsGltf()
 		{
-			var current = GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary;
+			var current = settings.EditorExportsAsBinary;
 			current = !current;
-			GLTFSettings.GetOrCreateSettings().EditorExportsAsBinary = current;
+			settings.EditorExportsAsBinary = current;
 			Menu.SetChecked(ExportAsBinary, current);
 		}
 	}

--- a/Editor/Scripts/GLTFExportMenu.cs
+++ b/Editor/Scripts/GLTFExportMenu.cs
@@ -263,17 +263,17 @@ namespace UnityGLTF
 
 		    protected override bool OnOpenStage() => true;
 
-		    public void Setup(string scenePath)
-		    {
-#if !UNITY_2023_1_OR_NEWER
-			    if (_openPreviewScene == null) _openPreviewScene = typeof(EditorSceneManager).GetMethod("OpenPreviewScene", (BindingFlags)(-1), null, new[] {typeof(string), typeof(bool)}, null);
-			    if (_openPreviewScene == null) return;
-			    
-			    scene = (Scene) _openPreviewScene.Invoke(null, new object[] { scenePath, false });
-#else
-			    scene = EditorSceneManager.OpenPreviewScene(scenePath, false);
-#endif
-		    }
+// 		    public void Setup(string scenePath)
+// 		    {
+// #if !UNITY_2023_1_OR_NEWER
+// 			    if (_openPreviewScene == null) _openPreviewScene = typeof(EditorSceneManager).GetMethod("OpenPreviewScene", (BindingFlags)(-1), null, new[] {typeof(string), typeof(bool)}, null);
+// 			    if (_openPreviewScene == null) return;
+// 			    
+// 			    scene = (Scene) _openPreviewScene.Invoke(null, new object[] { scenePath, false });
+// #else
+// 			    scene = EditorSceneManager.OpenPreviewScene(scenePath, false);
+// #endif
+// 		    }
 		    
 		    protected override GUIContent CreateHeaderContent()
 		    {

--- a/Editor/Scripts/Interactivity/VisualScriptingExport/Helpers/LogHelper.cs
+++ b/Editor/Scripts/Interactivity/VisualScriptingExport/Helpers/LogHelper.cs
@@ -1,0 +1,82 @@
+using System;
+using Unity.VisualScripting;
+using UnityGLTF.Interactivity.Schema;
+using UnityGLTF.Interactivity.VisualScripting.Export;
+
+namespace UnityGLTF.Interactivity.VisualScripting
+{
+    public static class LogHelper
+    {
+        public enum LogLevel
+        {
+            Info,
+            Warning,
+            Error
+        }
+        
+        public static void AddLog(UnitExporter unitExporter, LogLevel level, ValueInput messageInput, ControlInput enter, ControlOutput exit)
+        {
+            var addGltfLog = unitExporter.exportContext.plugin.debugLogSetting.GltfLog;
+            var addBabylon = unitExporter.exportContext.plugin.debugLogSetting.BabylonLog;
+            var addADBE = unitExporter.exportContext.plugin.debugLogSetting.ADBEConsole;
+
+            if (!addBabylon && !addADBE && !addGltfLog)
+            {
+                UnitExportLogging.AddWarningLog(unitExporter.unit, "No debug log output selected for Debug.Log unit. Skipping export. See Project Settings > UnityGltf");
+                return;
+            }
+            
+            var sequence_node = unitExporter.CreateNode(new Flow_SequenceNode());
+           
+            if (addGltfLog)
+            {
+                string messagePrefix = "";
+                switch (level)
+                {
+                    case LogLevel.Warning:
+                        messagePrefix = "Warning: ";
+                        break;
+                    case LogLevel.Error:
+                        messagePrefix = "Error: ";
+                        break;
+                }
+        
+                var gltf_Node = unitExporter.CreateNode(new Debug_LogNode());
+                if (unitExporter.IsInputLiteralOrDefaultValue(messageInput, out var message))
+                {
+                    gltf_Node.Configuration[Debug_LogNode.IdConfigMessage].Value = messagePrefix + message;
+                }
+                else
+                {
+                    gltf_Node.Configuration[Debug_LogNode.IdConfigMessage].Value = messagePrefix + "{0}";
+                    gltf_Node.ValueIn("0").MapToInputPort(messageInput);
+                }
+                
+                sequence_node.FlowOut("0").ConnectToFlowDestination(gltf_Node.FlowIn(Debug_LogNode.IdFlowIn));
+            }
+            
+            if (addADBE)
+            {
+                var adbe_node = unitExporter.CreateNode(new ADBE_OutputConsoleNode());
+
+                adbe_node.ValueIn(ADBE_OutputConsoleNode.IdMessage).MapToInputPort(messageInput);
+                sequence_node.FlowOut("1").ConnectToFlowDestination(adbe_node.FlowIn(ADBE_OutputConsoleNode.IdFlowIn));
+
+                unitExporter.exportContext.exporter.DeclareExtensionUsage(ADBE_OutputConsoleNode.EXTENSION_ID, false);
+            }
+
+            if (addBabylon)
+            {
+                var babylon_node = unitExporter.CreateNode(new Babylon_LogNode());
+             
+                babylon_node.ValueIn(Babylon_LogNode.IdMessage).MapToInputPort(messageInput);
+                sequence_node.FlowOut("2").ConnectToFlowDestination(babylon_node.FlowIn(Babylon_LogNode.IdFlowIn));
+    
+                unitExporter.exportContext.exporter.DeclareExtensionUsage(Babylon_LogNode.EXTENSION_ID, false);
+            }
+            
+            sequence_node.FlowOut("9").MapToControlOutput(exit);
+            sequence_node.FlowIn(Flow_SequenceNode.IdFlowIn).MapToControlInput(enter);
+        }
+    }
+}

--- a/Editor/Scripts/Interactivity/VisualScriptingExport/Helpers/LogHelper.cs.meta
+++ b/Editor/Scripts/Interactivity/VisualScriptingExport/Helpers/LogHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 961d5f3b564b4040a7f42e3066048042
+timeCreated: 1743662022

--- a/Editor/Scripts/Interactivity/VisualScriptingExport/InteractivityExportCallback.cs
+++ b/Editor/Scripts/Interactivity/VisualScriptingExport/InteractivityExportCallback.cs
@@ -19,6 +19,24 @@ namespace UnityGLTF.Interactivity.VisualScripting
             newNode.Index = nodes.Count - 1;
             return newNode;
         }
+
+        public GltfInteractivityExportNode AddLog(LogHelper.LogLevel level, string messageTemplate)
+        {
+            string messagePrefix = "";
+            switch (level)
+            {
+                case LogHelper.LogLevel.Warning:
+                    messagePrefix = "Warning: ";
+                    break;
+                case LogHelper.LogLevel.Error:
+                    messagePrefix = "Error: ";
+                    break;
+            }
+            
+            var gltf_Node = CreateNode(new Debug_LogNode());
+            gltf_Node.Configuration[Debug_LogNode.IdConfigMessage].Value = messagePrefix + messageTemplate;
+            return gltf_Node;
+        }
         
         internal GltfInteractivityExportNodes(List<GltfInteractivityExportNode> nodes)
         {

--- a/Editor/Scripts/Interactivity/VisualScriptingExport/UnitExporters/Misc/Debug_LogUnitExport.cs
+++ b/Editor/Scripts/Interactivity/VisualScriptingExport/UnitExporters/Misc/Debug_LogUnitExport.cs
@@ -28,63 +28,9 @@ namespace UnityGLTF.Interactivity.VisualScripting.Export
             bool isWarning = unit.member.name == nameof(Debug.LogWarning);
             bool isError = unit.member.name == nameof(Debug.LogError);
             
-            var addGltfLog = unitExporter.exportContext.plugin.debugLogSetting.GltfLog;
-            var addBabylon = unitExporter.exportContext.plugin.debugLogSetting.BabylonLog;
-            var addADBE = unitExporter.exportContext.plugin.debugLogSetting.ADBEConsole;
-
-            if (!addBabylon && !addADBE && !addGltfLog)
-            {
-                UnitExportLogging.AddWarningLog(unit,"No debug log output selected for Debug.Log unit. Skipping export. See Project Settings > UnityGltf");
-                return false;
-            }
+            LogHelper.AddLog(unitExporter, isWarning ? LogHelper.LogLevel.Warning : isError ? LogHelper.LogLevel.Error : LogHelper.LogLevel.Info,
+                unit.inputParameters[0], unit.enter, unit.exit);
             
-            var sequence_node = unitExporter.CreateNode(new Flow_SequenceNode());
-           
-            if (addGltfLog)
-            {
-                string messagePrefix = "";
-                if (isWarning)
-                    messagePrefix = "Warning: ";
-                else if (isError)
-                    messagePrefix = "Error: ";
-
-                var gltf_Node = unitExporter.CreateNode(new Debug_LogNode());
-                if (unitExporter.IsInputLiteralOrDefaultValue(unit.inputParameters[0], out var message))
-                {
-                    gltf_Node.Configuration[Debug_LogNode.IdConfigMessage].Value = messagePrefix + message;
-                }
-                else
-                {
-                    gltf_Node.Configuration[Debug_LogNode.IdConfigMessage].Value = messagePrefix + "{0}";
-                    gltf_Node.ValueIn("0").MapToInputPort(unit.inputParameters[0]);
-                }
-                
-                sequence_node.FlowOut("0").ConnectToFlowDestination(gltf_Node.FlowIn(Debug_LogNode.IdFlowIn));
-            }
-            
-            if (addADBE)
-            {
-                var adbe_node = unitExporter.CreateNode(new ADBE_OutputConsoleNode());
-
-                adbe_node.ValueIn(ADBE_OutputConsoleNode.IdMessage).MapToInputPort(unit.inputParameters[0]);
-                sequence_node.FlowOut("1").ConnectToFlowDestination(adbe_node.FlowIn(ADBE_OutputConsoleNode.IdFlowIn));
-
-                unitExporter.exportContext.exporter.DeclareExtensionUsage(ADBE_OutputConsoleNode.EXTENSION_ID, false);
-            }
-
-            if (addBabylon)
-            {
-                var babylon_node = unitExporter.CreateNode(new Babylon_LogNode());
-             
-                babylon_node.ValueIn(Babylon_LogNode.IdMessage).MapToInputPort(unit.inputParameters[0]);
-                sequence_node.FlowOut("2").ConnectToFlowDestination(babylon_node.FlowIn(Babylon_LogNode.IdFlowIn));
-    
-                unitExporter.exportContext.exporter.DeclareExtensionUsage(Babylon_LogNode.EXTENSION_ID, false);
-            }
-            
-            sequence_node.FlowOut("9").MapToControlOutput(unit.exit);
-            sequence_node.FlowIn(Flow_SequenceNode.IdFlowIn).MapToControlInput(unit.enter);
-   
             return true;
         }
 

--- a/Editor/Scripts/Interactivity/VisualScriptingExport/VisualScriptingExportContext.cs
+++ b/Editor/Scripts/Interactivity/VisualScriptingExport/VisualScriptingExportContext.cs
@@ -1147,22 +1147,22 @@ namespace UnityGLTF.Interactivity.VisualScripting
             RemoveNodes(nodesToRemove);
         }
         
-        private GltfInteractivityNode[] AddTypeConversion(GltfInteractivityNode targetNode, int conversionNodeIndex, string targetInputSocket, int fromType, int toType)
+        private GltfInteractivityExportNode[] AddTypeConversion(GltfInteractivityExportNode targetNode, int conversionNodeIndex, string targetInputSocket, int fromType, int toType)
         {
-            List<GltfInteractivityNode> newNodes = new List<GltfInteractivityNode>();
+            var newNodes = new List<GltfInteractivityExportNode>();
             
             var fromTypeSignature = GltfTypes.TypesMapping[fromType].GltfSignature;
             var toTypeSignature = GltfTypes.TypesMapping[toType].GltfSignature;
 
             var targetSocketData = targetNode.ValueInConnection[targetInputSocket];
-            GltfInteractivityNode conversionNode = null;
+            GltfInteractivityExportNode conversionNode = null;
             
             var fromTypeComponentCount = GltfTypes.GetComponentCount(fromTypeSignature);
             var toTypeComponentCount = GltfTypes.GetComponentCount(toTypeSignature);
             
             void SetupSimpleConversion(GltfInteractivityNodeSchema schema)
             {
-                conversionNode= new GltfInteractivityNode(schema);
+                conversionNode = new GltfInteractivityExportNode(schema);
                 conversionNode.Index = conversionNodeIndex;
                 newNodes.Add(conversionNode);
                 conversionNode.ValueInConnection["a"] = new GltfInteractivityNode.ValueSocketData()
@@ -1180,7 +1180,7 @@ namespace UnityGLTF.Interactivity.VisualScripting
             
             void SetupConversion(GltfInteractivityNodeSchema schema)
             {
-                conversionNode= new GltfInteractivityNode(schema);
+                conversionNode= new GltfInteractivityExportNode(schema);
                 conversionNode.Index = conversionNodeIndex;
                 newNodes.Add(conversionNode);
 

--- a/README.md
+++ b/README.md
@@ -142,8 +142,12 @@ The lists below are non-conclusive and in no particular order. Note that there a
 - [KHR_materials_specular](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_specular/README.md) (partial support)
 - [KHR_materials_dispersion](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_dispersion/README.md) (refractive index dispersion)
 - [KHR_animation_pointer](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_animation_pointer/README.md) (arbitrary property animations)
-- [KHR_node_visibility](https://github.com/KhronosGroup/glTF/blob/fbe806836526cdd8cd99ed3770b1c56df56c6863/extensions/2.0/Khronos/KHR_node_visibility/README.md) (GameObject active state) ![Non-Ratified Extension](https://img.shields.io/badge/⚠️%20Non--Ratified%20Extension-gray)
 - [MSFT_lod](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/MSFT_lod/README.md) (level of detail) ![Vendor-specific Extension](https://img.shields.io/badge/⚠️%20Vendor--specific%20Extension-gray)
+- [KHR_node_visibility](https://github.com/KhronosGroup/glTF/blob/fbe806836526cdd8cd99ed3770b1c56df56c6863/extensions/2.0/Khronos/KHR_node_visibility/README.md) (GameObject active state) ![Non-Ratified Extension](https://img.shields.io/badge/⚠️%20Non--Ratified%20Extension-gray)
+- [`KHR_node_hoverability`](https://github.com/KhronosGroup/glTF/pull/2426) ![Non-Ratified Extension](https://img.shields.io/badge/⚠️%20Non--Ratified%20Extension-gray)
+- [`KHR_node_selectability`](https://github.com/KhronosGroup/glTF/pull/2422) ![Non-Ratified Extension](https://img.shields.io/badge/⚠️%20Non--Ratified%20Extension-gray)
+- [KHR_interactivity](https://github.com/KhronosGroup/glTF/blob/220ca407a2ce1f8463855803778edf73a885b7e9/extensions/2.0/Khronos/KHR_interactivity/Specification.adoc) (Visual Scripting export as interactivity graph) ![Non-Ratified Extension](https://img.shields.io/badge/⚠️%20Non--Ratified%20Extension-gray)
+
 ### Import only
 
 - [KHR_mesh_quantization](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_mesh_quantization/README.md) (smaller buffers / smaller filesize)

--- a/Runtime/Scripts/GLTFSettings.cs
+++ b/Runtime/Scripts/GLTFSettings.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using UnityGLTF.Plugins;
 using System.Reflection;
+using UnityEngine.Serialization;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -108,23 +109,30 @@ namespace UnityGLTF
 	    public enum TransformMode
 	    {
 		    /** Reset local position, keep local rotation, keep world scale. This is a heuristic for exporting objects from anywhere in the scene for general usage. */
-		    AutoTransforms,
+		    [InspectorName(("Auto: reset local position, keep local rotation, keep world scale"))]
+		    Auto,
 		    /** Keep local position, rotation, and scale. This is useful if you want to export childs of hierarchies and import them again as childs. */
+		    [InspectorName("Local: keep local position, rotation and scale")]
 		    LocalTransforms,
 		    /** Keep world position, rotation, and scale. This is useful for exporting parts of scenes and keeping all relations between objects the same. */
+		    [InspectorName("World: keep world position, rotation and scale")]
 		    WorldTransforms,
 	    }
 	    
-	    [Tooltip("AutoTransform: Reset local position, keep local rotation, keep world scale. \nLocalTransforms: Keep local position, rotation, and scale. \nWorldTransforms: Keep world position, rotation, and scale.")]
-	    public TransformMode EditorExportTransformMode = TransformMode.AutoTransforms;
+	    [Tooltip("Specifies how root transforms will be exported.\nAuto (default): reset local position, keep local rotation, keep world scale. \nLocalTransforms: keep local position, rotation, and scale. \nWorldTransforms: keep world position, rotation, and scale.")]
+	    public TransformMode EditorExportTransformMode = TransformMode.Auto;
 
 	    public enum ExportFileFormat
 	    {
+		    /** glTF-Binary (GLB) with embedded buffers and textures */
+		    [InspectorName("glTF-Binary (.glb)")]
 		    Glb,
-		    Gltf
+		    /** glTF JSON + separate binary buffers and textures */
+		    [InspectorName("glTF (.gltf + .bin + textures)")]
+		    Gltf,
 	    }
 	    
-	    public ExportFileFormat EditorExportsFileFormat = ExportFileFormat.Glb;
+	    public ExportFileFormat EditorExportFileFormat = ExportFileFormat.Glb;
 #endif
 	    
 		[Header("Export Visibility")]

--- a/Runtime/Scripts/GLTFSettings.cs
+++ b/Runtime/Scripts/GLTFSettings.cs
@@ -124,7 +124,6 @@ namespace UnityGLTF
 		    Gltf
 	    }
 	    
-	    [Tooltip("If true, the exported glTF file will be in Glb format. \nIf false, it will be in Gltf format.")]
 	    public ExportFileFormat EditorExportsFileFormat = ExportFileFormat.Glb;
 #endif
 	    

--- a/Runtime/Scripts/GLTFSettings.cs
+++ b/Runtime/Scripts/GLTFSettings.cs
@@ -104,6 +104,21 @@ namespace UnityGLTF
 		[SerializeField]
 		private bool requireExtensions = false;
 
+#if UNITY_EDITOR
+	    public enum TransformMode
+	    {
+		    /** Reset local position, keep local rotation, keep world scale. This is a heuristic for exporting objects from anywhere in the scene for general usage. */
+		    AutoTransforms,
+		    /** Keep local position, rotation, and scale. This is useful if you want to export childs of hierarchies and import them again as childs. */
+		    LocalTransforms,
+		    /** Keep world position, rotation, and scale. This is useful for exporting parts of scenes and keeping all relations between objects the same. */
+		    WorldTransforms,
+	    }
+	    
+	    [Tooltip("AutoTransform: Reset local position, keep local rotation, keep world scale. \nLocalTransforms: Keep local position, rotation, and scale. \nWorldTransforms: Keep world position, rotation, and scale.")]
+	    public TransformMode EditorExportTransformMode = TransformMode.AutoTransforms;
+#endif
+	    
 		[Header("Export Visibility")]
 		[SerializeField]
 		[Tooltip("Uses Camera.main layer settings to filter which objects are exported")]

--- a/Runtime/Scripts/GLTFSettings.cs
+++ b/Runtime/Scripts/GLTFSettings.cs
@@ -117,8 +117,15 @@ namespace UnityGLTF
 	    
 	    [Tooltip("AutoTransform: Reset local position, keep local rotation, keep world scale. \nLocalTransforms: Keep local position, rotation, and scale. \nWorldTransforms: Keep world position, rotation, and scale.")]
 	    public TransformMode EditorExportTransformMode = TransformMode.AutoTransforms;
-		[Tooltip("If true, the exported glTF file will be in Glb format. \nIf false, it will be in Gltf format.")]
-	    public bool EditorExportsAsBinary = true;
+
+	    public enum ExportFileFormat
+	    {
+		    Glb,
+		    Gltf
+	    }
+	    
+	    [Tooltip("If true, the exported glTF file will be in Glb format. \nIf false, it will be in Gltf format.")]
+	    public ExportFileFormat EditorExportsFileFormat = ExportFileFormat.Glb;
 #endif
 	    
 		[Header("Export Visibility")]

--- a/Runtime/Scripts/GLTFSettings.cs
+++ b/Runtime/Scripts/GLTFSettings.cs
@@ -117,6 +117,8 @@ namespace UnityGLTF
 	    
 	    [Tooltip("AutoTransform: Reset local position, keep local rotation, keep world scale. \nLocalTransforms: Keep local position, rotation, and scale. \nWorldTransforms: Keep world position, rotation, and scale.")]
 	    public TransformMode EditorExportTransformMode = TransformMode.AutoTransforms;
+		[Tooltip("If true, the exported glTF file will be in Glb format. \nIf false, it will be in Gltf format.")]
+	    public bool EditorExportsAsBinary = true;
 #endif
 	    
 		[Header("Export Visibility")]

--- a/Runtime/Scripts/Interactivity/Schema/GltfInteractivityNode.cs
+++ b/Runtime/Scripts/Interactivity/Schema/GltfInteractivityNode.cs
@@ -36,15 +36,14 @@ namespace UnityGLTF.Interactivity.Schema
         
         public void SetFlowOut(string socketId, GltfInteractivityNode targetNode, string targetSocketId)
         {
-            if (FlowConnections.TryGetValue(socketId, out var socket))
+            if (!FlowConnections.TryGetValue(socketId, out var socket))
             {
-                socket.Node = targetNode.Index;
-                socket.Socket = targetSocketId;
+                socket = new FlowSocketData();
+                FlowConnections.Add(socketId, socket);
             }
-            else
-            {
-                Debug.LogError($"Socket {socketId} not found in node {Schema.Op}");
-            }
+
+            socket.Node = targetNode.Index;
+            socket.Socket = targetSocketId;
         }
 
         public virtual void SetSchema(GltfInteractivityNodeSchema schema, bool applySocketDescriptors, bool clearExistingSocketData = true)
@@ -90,38 +89,36 @@ namespace UnityGLTF.Interactivity.Schema
         
         public void SetValueInSocketSource(string socketId,  GltfInteractivityNode sourceNode, string sourceSocketId, TypeRestriction typeRestriction = null)
         {
-            if (ValueInConnection.TryGetValue(socketId, out var socket))
+            if (!ValueInConnection.TryGetValue(socketId, out var socket))
             {
-                socket.Node = sourceNode.Index;
-                socket.Socket = sourceSocketId;
-                socket.Value = null;
-                socket.Type = -1;
-                if (typeRestriction != null)
-                    socket.typeRestriction = typeRestriction;
+                socket = new ValueSocketData(); 
+                ValueInConnection.Add(socketId, socket);
             }
-            else
-            {
-                Debug.LogError($"Socket {socketId} not found in node {Schema.Op}");
-            }
+            
+            socket.Node = sourceNode.Index;
+            socket.Socket = sourceSocketId;
+            socket.Value = null;
+            socket.Type = -1;
+            if (typeRestriction != null)
+                socket.typeRestriction = typeRestriction;
         }
         
         public void SetValueInSocket(string socketId, object value, TypeRestriction typeRestriction = null)
         {
-            if (ValueInConnection.TryGetValue(socketId, out var socket))
+            if (!ValueInConnection.TryGetValue(socketId, out var socket))
             {
-                socket.Node = null;
-                socket.Socket = null;
-                socket.Value = value;
-                if (value != null)
-                    socket.Type =  GltfTypes.TypeIndex(value.GetType());
-                
-                if (typeRestriction != null)
-                    socket.typeRestriction = typeRestriction;
+                socket = new ValueSocketData(); 
+                ValueInConnection.Add(socketId, socket);
             }
-            else
-            {
-                Debug.LogError($"Socket {socketId} not found in node {Schema.Op}");
-            }
+            
+            socket.Node = null;
+            socket.Socket = null;
+            socket.Value = value;
+            if (value != null)
+                socket.Type =  GltfTypes.TypeIndex(value.GetType());
+            
+            if (typeRestriction != null)
+                socket.typeRestriction = typeRestriction;
         }
         
         public GltfInteractivityNode(GltfInteractivityNodeSchema schema)


### PR DESCRIPTION
Previously, exported root transforms were always in local space. This lead to some confusing exports where objects were off-center, or aligned in unclear ways to each other when multiple childs of differently transformed root objects were exported together as one file.

This PR adds new options for choosing the intended behaviour – keeping Local space, keeping World space, or Auto.

Here's what the modes do:
| Mode | Behaviour |
| - | - |
| Local | keep local position<br/>keep local rotation<br/>keep local scale |
| World |keep world position<br/>keep world rotation<br/>keep world scale |
| Auto | reset local position to 0,0,0<br/>keep local rotation<br/>keep world scale |

The behaviour of the "Auto" mode is heuristically determined from lots of testing.