### PR TITLE
Add async callbacks to GLTFImportPluginContext

### DIFF
--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -430,7 +430,7 @@ namespace UnityGLTF
 				// TODO check where the right place is to call OnBeforeImport as early as possible
 				foreach (var plugin in Context.Plugins)
 				{
-					plugin.OnBeforeImport();
+					await plugin.OnBeforeImportAsync();
 				}
 
 				if (_options.ThrowOnLowMemory)
@@ -458,14 +458,14 @@ namespace UnityGLTF
 				if (_gltfRoot == null)
 				{
 					foreach (var plugin in Context.Plugins)
-						plugin.OnBeforeImportRoot();
+						await plugin.OnBeforeImportRootAsync();
 					await LoadJson(_gltfFileName);
 					progressStatus.IsDownloaded = true;
 				}
 
 				foreach (var plugin in Context.Plugins)
 				{
-					plugin.OnAfterImportRoot(_gltfRoot);
+					await plugin.OnAfterImportRootAsync(_gltfRoot);
 				}
 
 				cancellationToken.ThrowIfCancellationRequested();
@@ -683,7 +683,7 @@ namespace UnityGLTF
 			try
 			{
 				foreach (var plugin in Context.Plugins)
-					plugin.OnBeforeImportScene(scene);
+					await plugin.OnBeforeImportSceneAsync(scene);
 			}
 			catch (Exception e)
 			{
@@ -731,7 +731,7 @@ namespace UnityGLTF
 			try
 			{
 				foreach (var plugin in Context.Plugins)
-					plugin.OnAfterImportScene(scene, sceneIndex, CreatedObject);
+					await plugin.OnAfterImportSceneAsync(scene, sceneIndex, CreatedObject);
 			}
 			catch (Exception e)
 			{
@@ -821,7 +821,7 @@ namespace UnityGLTF
 					try
 					{
 						foreach (var plugin in Context.Plugins)
-							plugin.OnAfterImportNode(node, nodeId, _assetCache.NodeCache[nodeId]);
+							await plugin.OnAfterImportNodeAsync(node, nodeId, _assetCache.NodeCache[nodeId]);
 					}
 					catch (Exception ex)
 					{

--- a/Runtime/Scripts/Plugins/Core/GltfImportPlugin.cs
+++ b/Runtime/Scripts/Plugins/Core/GltfImportPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using GLTF.Schema;
 using UnityEngine;
 
@@ -61,5 +62,51 @@ namespace UnityGLTF.Plugins
 		{
 
 		}
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously.
+		// These methods can be overridden if an importer needs to call async functions.
+		// These are provided for backwards compatibility and by default, will call the
+		// synchronous version.
+
+		public virtual async Task OnBeforeImportAsync()
+		{
+			OnBeforeImport();
+		}
+
+		public virtual async Task OnBeforeImportRootAsync()
+		{
+			OnBeforeImportRoot();
+		}
+
+		public virtual async Task OnAfterImportRootAsync(GLTFRoot gltfRoot)
+		{
+			OnAfterImportRoot(gltfRoot);
+		}
+
+		public virtual async Task OnBeforeImportSceneAsync(GLTFScene scene)
+		{
+			OnBeforeImportScene(scene);
+		}
+
+		public virtual async Task OnAfterImportNodeAsync(Node node, int nodeIndex, GameObject nodeObject)
+		{
+			OnAfterImportNode(node, nodeIndex, nodeObject);
+		}
+
+		public virtual async Task OnAfterImportMaterialAsync(GLTFMaterial material, int materialIndex, Material materialObject)
+		{
+			OnAfterImportMaterial(material, materialIndex, materialObject);
+		}
+
+		public virtual async Task OnAfterImportTextureAsync(GLTFTexture texture, int textureIndex, Texture textureObject)
+		{
+			OnAfterImportTexture(texture, textureIndex, textureObject);
+		}
+
+		public virtual async Task OnAfterImportSceneAsync(GLTFScene scene, int sceneIndex, GameObject sceneObject)
+		{
+			OnAfterImportScene(scene, sceneIndex, sceneObject);
+		}
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously.
 	}
 }

--- a/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
@@ -790,7 +790,7 @@ namespace UnityGLTF
 
 			foreach (var plugin in Context.Plugins)
 			{
-				plugin.OnAfterImportMaterial(def, materialIndex, mapper.Material);
+				await plugin.OnAfterImportMaterialAsync(def, materialIndex, mapper.Material);
 			}
 		}
 

--- a/Runtime/Scripts/SceneImporter/ImporterTextures.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterTextures.cs
@@ -658,7 +658,7 @@ namespace UnityGLTF
 
 				foreach (var plugin in Context.Plugins)
 				{
-					plugin.OnAfterImportTexture(texture, textureIndex, tex);
+					await plugin.OnAfterImportTextureAsync(texture, textureIndex, tex);
 				}
 			}
 			catch (Exception ex)


### PR DESCRIPTION
I had a use-case when implementing an import plugin and needed to call an async function. Attempting to do this from the synchronous callbacks would either trigger exceptions due to code which should only run on the main thread or would hang Unity.

This PR extends the GLTFImportContext to provide async versions of the callbacks; for backwards-compatibility, the base implementation calls the synchronous version, so any extant implementations of the GLTFImportPluginContext should not see any API changes due to this.

For my use-case, I just needed an async OnAfterImportNode(), but saw no reason that this shouldn't be supported for each callback.