### PR TITLE
Marked BaseColor and BaseTexture as main properties to get rid of the error while using regular Material.color property.

### DIFF
--- a/Runtime/Shaders/ShaderGraph/PBRGraph.shadergraph
+++ b/Runtime/Shaders/ShaderGraph/PBRGraph.shadergraph
@@ -22044,7 +22044,7 @@
         "b": 1.0,
         "a": 1.0
     },
-    "isMainColor": false,
+    "isMainColor": true,
     "m_ColorMode": 0
 }
 
@@ -23067,7 +23067,7 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
-    "isMainTexture": false,
+    "isMainTexture": true,
     "useTilingAndOffset": true,
     "m_Modifiable": true,
     "m_DefaultType": 0

--- a/Runtime/Shaders/ShaderGraph/UnlitGraph.shadergraph
+++ b/Runtime/Shaders/ShaderGraph/UnlitGraph.shadergraph
@@ -1584,7 +1584,7 @@
         "b": 1.0,
         "a": 1.0
     },
-    "isMainColor": false,
+    "isMainColor": true,
     "m_ColorMode": 0
 }
 
@@ -1617,7 +1617,7 @@
         "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
         "m_Guid": ""
     },
-    "isMainTexture": false,
+    "isMainTexture": true,
     "useTilingAndOffset": true,
     "m_Modifiable": true,
     "m_DefaultType": 0


### PR DESCRIPTION
This PR fixes the error described in https://github.com/KhronosGroup/UnityGLTF/issues/863.

As @hybridherbst requested, the diff is very small.

Simply clicking this menu option did the trick (on both base color and base texture on both lit and unlit shaders).

![image](https://github.com/user-attachments/assets/f7620eca-ddaf-4b9f-a345-7db6cdfaaefa)
