### PR TITLE
Made Importer create Material with Auto Queue Control. The user can override it if he wants.

### DIFF
--- a/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
@@ -100,8 +100,8 @@ namespace UnityGLTF
 			mapper.AlphaMode = def.AlphaMode;
 			mapper.AlphaCutoff = def.AlphaCutoff;
 			mapper.DoubleSided = def.DoubleSided;
-			mapper.Material.SetFloat("_BUILTIN_QueueControl", -1);
-			mapper.Material.SetFloat("_QueueControl", -1);
+			mapper.Material.SetFloat("_BUILTIN_QueueControl", 0);
+			mapper.Material.SetFloat("_QueueControl", 0);
 
 #if UNITY_EDITOR
 			if (Context.SourceImporter == null)


### PR DESCRIPTION
This PR fixes the problem mentioned in https://github.com/KhronosGroup/UnityGLTF/issues/865

If you agree, the user should be able to receive a material from the importer with Queue Control set to "Auto". If he wants, he can extract the material and override the queue however he likes.