### PR TITLE
Enabled applyRootMotion for humanoid animator to make it consistent with FBX importer.

### DIFF
--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -1393,10 +1393,12 @@ namespace UnityGLTF
 				}
 
 				if (_options.AnimationMethod == AnimationMethod.MecanimHumanoid)
-				{
-					if (!sceneObj.GetComponent<Animator>())
-						sceneObj.AddComponent<Animator>();
-				}
+                {
+                    var animator = sceneObj.GetComponent<Animator>();
+                    if (!animator) animator = sceneObj.AddComponent<Animator>();
+
+                    animator.applyRootMotion = true;
+                }
 
 				CreatedObject = sceneObj;
 				InitializeGltfTopLevelObject();


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/KhronosGroup/UnityGLTF/issues/867

Before:
![image](https://github.com/user-attachments/assets/93d3603c-8d7b-4fc9-8bfc-6f7786132b96)

After:
![image](https://github.com/user-attachments/assets/7bea321e-100f-4aa3-9e3c-d5cb205a97f2)

