### PR TITLE
Enabled applyRootMotion for non-humanoid animator to make it consistent with FBX importer.

### DIFF
--- a/Editor/Scripts/Interactivity/VisualScriptingExport/UnitExporters/Math/VectorQuaternionMatrixExposeUnitExports.cs
+++ b/Editor/Scripts/Interactivity/VisualScriptingExport/UnitExporters/Math/VectorQuaternionMatrixExposeUnitExports.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Unity.VisualScripting;
 using UnityEditor;
 using UnityEngine;
+using UnityGLTF.Interactivity.Export;
 using UnityGLTF.Interactivity.Schema;
 
 namespace UnityGLTF.Interactivity.VisualScripting.Export
@@ -11,14 +12,7 @@ namespace UnityGLTF.Interactivity.VisualScripting.Export
     public class VectorQuaternionMatrixExposeUnitExports : IUnitExporter
     {
         private static readonly string[] VectorMemberIndex = new string[] { "x", "y", "z", "w" };
-
-        private static readonly string[] MatrixMemberIndex = new string[]
-        {
-            "m00", "m10", "m20", "m30", "m01", "m11", "m21", "m31", "m02", "m12", "m22", "m32", "m03", "m13", "m23",
-            "m33"
-        };
-
-
+        
         public Type unitType
         {
             get => typeof(Expose);
@@ -31,7 +25,7 @@ namespace UnityGLTF.Interactivity.VisualScripting.Export
             ExposeUnitExport.RegisterExposeConvert(typeof(Vector2), converter, "x", "y");
             ExposeUnitExport.RegisterExposeConvert(typeof(Vector3), converter, "x", "y", "z");
             ExposeUnitExport.RegisterExposeConvert(typeof(Vector4), converter, "x", "y", "z", "w");
-            var matrixMembers = MatrixMemberIndex.Concat(new string[] {nameof(Matrix4x4.lossyScale), nameof(Matrix4x4.rotation)}).ToArray();
+            var matrixMembers = MatrixHelpers.MatrixMemberIndex.Concat(new string[] {nameof(Matrix4x4.lossyScale), nameof(Matrix4x4.rotation)}).ToArray();
             ExposeUnitExport.RegisterExposeConvert(typeof(Matrix4x4), converter, matrixMembers);
 
             ExposeUnitExport.RegisterExposeConvert(typeof(Quaternion), converter, "x", "y", "z", "w");
@@ -48,8 +42,8 @@ namespace UnityGLTF.Interactivity.VisualScripting.Export
                 GetMemberUnitExport.RegisterMemberExporter(typeof(Quaternion), VectorMemberIndex[i], converter);
             }
 
-            for (int i = 0; i < MatrixMemberIndex.Length; i++)
-                GetMemberUnitExport.RegisterMemberExporter(typeof(Matrix4x4), MatrixMemberIndex[i], converter);
+            for (int i = 0; i < MatrixHelpers.MatrixMemberIndex.Length; i++)
+                GetMemberUnitExport.RegisterMemberExporter(typeof(Matrix4x4), MatrixHelpers.MatrixMemberIndex[i], converter);
         }
 
         public bool InitializeInteractivityNodes(UnitExporter unitExporter)
@@ -115,9 +109,9 @@ namespace UnityGLTF.Interactivity.VisualScripting.Export
             {
                 if (isMatrix)
                 {
-                    for (int i = 0; i < MatrixMemberIndex.Length; i++)
+                    for (int i = 0; i < MatrixHelpers.MatrixMemberIndex.Length; i++)
                     {
-                        if (member.name == MatrixMemberIndex[i])
+                        if (member.name == MatrixHelpers.MatrixMemberIndex[i])
                         {
                             unitExporter.MapValueOutportToSocketName(port, i.ToString(), node);
                             break;

--- a/Editor/Scripts/Interactivity/VisualScriptingExport/UnitExporters/Math/VectorQuaternionMatrixSetComponentsUnitExports.cs
+++ b/Editor/Scripts/Interactivity/VisualScriptingExport/UnitExporters/Math/VectorQuaternionMatrixSetComponentsUnitExports.cs
@@ -2,6 +2,7 @@ using System;
 using Unity.VisualScripting;
 using UnityEditor;
 using UnityEngine;
+using UnityGLTF.Interactivity.Export;
 using UnityGLTF.Interactivity.Schema;
 
 namespace UnityGLTF.Interactivity.VisualScripting.Export
@@ -12,13 +13,6 @@ namespace UnityGLTF.Interactivity.VisualScripting.Export
         
         private static readonly string[] VectorMemberIndex = new string[] { "x", "y", "z", "w" };
         private static readonly string[] InputNames = new string[] {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"};
-
-        
-        private static readonly string[] MatrixMemberIndex = new string[]
-        {
-            "m00", "m10", "m20", "m30", "m01", "m11", "m21", "m31", "m02", "m12", "m22", "m32", "m03", "m13", "m23",
-            "m33"
-        };
         
         [InitializeOnLoadMethod]
         private static void Register()
@@ -41,7 +35,7 @@ namespace UnityGLTF.Interactivity.VisualScripting.Export
             SetMemberUnitExport.RegisterMemberExporter(typeof(Quaternion), nameof(Quaternion.w), new VectorQuaternionMatrixSetComponentsUnitExports(4, 3) );
 
             for (int i = 0; i < 16; i++)
-                SetMemberUnitExport.RegisterMemberExporter(typeof(Matrix4x4), MatrixMemberIndex[i], new VectorQuaternionMatrixSetComponentsUnitExports(16, i) );
+                SetMemberUnitExport.RegisterMemberExporter(typeof(Matrix4x4), MatrixHelpers.MatrixMemberIndex[i], new VectorQuaternionMatrixSetComponentsUnitExports(16, i) );
         }
 
         private int componentCount;

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -1399,6 +1399,11 @@ namespace UnityGLTF
 
                     animator.applyRootMotion = true;
                 }
+                else if (_options.AnimationMethod == AnimationMethod.Mecanim)
+                {
+                    var animator = sceneObj.GetComponent<Animator>();
+                    if (animator) animator.applyRootMotion = true;
+                }
 
 				CreatedObject = sceneObj;
 				InitializeGltfTopLevelObject();

--- a/Runtime/Scripts/Interactivity/Export/Helpers/MatrixHelpers.cs
+++ b/Runtime/Scripts/Interactivity/Export/Helpers/MatrixHelpers.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+
+namespace UnityGLTF.Interactivity.Export
+{
+    public static class MatrixHelpers
+    {
+        public static readonly string[] MatrixMemberIndex = new string[]
+        {
+            "m00", "m01", "m02", "m03", "m10", "m11", "m12", "m13",
+            "m20", "m21", "m22", "m23", "m30", "m31", "m32", "m33"
+        };
+        
+        /// <summary>
+        /// Get the converted GLTF index for a given matrix element. 
+        /// </summary>
+        public static float GltfGetElement(Matrix4x4 m, int index)
+        {
+            switch (index)
+            {
+                case 0: return m.m00;
+                case 1: return m.m01;
+                case 2: return m.m02;
+                case 3: return m.m03;
+                case 4: return m.m10;
+                case 5: return m.m11;
+                case 6: return m.m12;
+                case 7: return m.m13;
+                case 8: return m.m20;
+                case 9: return m.m21;
+                case 10: return m.m22;
+                case 11: return m.m23;
+                case 12: return m.m30;
+                case 13: return m.m31;
+                case 14: return m.m32;
+                case 15: return m.m33;
+                default:
+                    throw new System.ArgumentOutOfRangeException(nameof(index), "Index must be between 0 and 15.");
+            }
+        }
+        
+        public static void GltfSetElement(ref Matrix4x4 m, int index, float value)
+        {
+            switch (index)
+            {
+                case 0: m.m00 = value; break;
+                case 1: m.m01 = value; break;
+                case 2: m.m02 = value; break;
+                case 3: m.m03 = value; break;
+                case 4: m.m10 = value; break;
+                case 5: m.m11 = value; break;
+                case 6: m.m12 = value; break;
+                case 7: m.m13 = value; break;
+                case 8: m.m20 = value; break;
+                case 9: m.m21 = value; break;
+                case 10: m.m22 = value; break;
+                case 11: m.m23 = value; break;
+                case 12: m.m30 = value; break;
+                case 13: m.m31 = value; break;
+                case 14: m.m32 = value; break;
+                case 15: m.m33 = value; break;
+                default:
+                    throw new System.ArgumentOutOfRangeException(nameof(index), "Index must be between 0 and 15.");
+            }
+        }
+        
+    }
+}

--- a/Runtime/Scripts/Interactivity/Export/Helpers/MatrixHelpers.cs.meta
+++ b/Runtime/Scripts/Interactivity/Export/Helpers/MatrixHelpers.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bb33c36e588f4379bcb672d6c77e7a5a
+timeCreated: 1749745169


### PR DESCRIPTION
This time, I made sure the importer doesn't create a redundant animator when model doesn't have an animation.

applyRootMotion is set to true only when an animation is already created for the "mecanim" animation type.