### PR TITLE
Independent Axis Scaling on Import

### DIFF
--- a/Editor/Scripts/GLTFImporterInspector.cs
+++ b/Editor/Scripts/GLTFImporterInspector.cs
@@ -81,7 +81,18 @@ namespace UnityGLTF
 			}
 			EditorGUILayout.LabelField("Scene", EditorStyles.boldLabel);
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._removeEmptyRootObjects)));
-			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._scaleFactor)));
+			
+			var useAxisScaleFactorProp = serializedObject.FindProperty(nameof(GLTFImporter._useAxisScaleFactor));
+			EditorGUILayout.PropertyField(useAxisScaleFactorProp, new GUIContent("Use Independent Axis Scale"));
+			if (useAxisScaleFactorProp.boolValue)
+			{
+				EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._axisScaleFactor)), new GUIContent("Scale Factor"));
+			}
+			else
+			{
+				EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._scaleFactor)));
+			}
+			
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._importCamera)));
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._deduplicateResources)));
 			// EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._maximumLod)), new GUIContent("Maximum Shader LOD"));

--- a/Runtime/Plugins/GLTFSerialization/GLTFHelpers.cs
+++ b/Runtime/Plugins/GLTFSerialization/GLTFHelpers.cs
@@ -352,9 +352,9 @@ namespace GLTF
 			}
 		}
 
-		public static void BuildTargetAttributes(ref Dictionary<string, AttributeAccessor> attributes, float importScale = 1f)
+		public static void BuildTargetAttributes(ref Dictionary<string, AttributeAccessor> attributes, float3 importScale)
 		{
-			var hasScale = !Mathf.Approximately(importScale, 1f);
+			var hasScale = !Mathf.Approximately(importScale.x, 1f) || !Mathf.Approximately(importScale.y, 1f) || !Mathf.Approximately(importScale.z, 1f);
 			
 			foreach (var kvp in attributes)
 			{
@@ -368,8 +368,7 @@ namespace GLTF
 					case SemanticProperties.POSITION:
 						if (hasScale)
 						{
-							float3 conversionScale = new float3(importScale, importScale, importScale);
-							attributeAccessor.AccessorId.Value.AsFloat3ArrayConversion(ref resultArray, bufferViewCache, conversionScale, 0, normalize);
+							attributeAccessor.AccessorId.Value.AsFloat3ArrayConversion(ref resultArray, bufferViewCache, importScale, 0, normalize);
 						}
 						else
 							attributeAccessor.AccessorId.Value.AsFloat3Array(ref resultArray, bufferViewCache, 0, normalize);

--- a/Runtime/Scripts/Plugins/Core/ImportContext.cs
+++ b/Runtime/Scripts/Plugins/Core/ImportContext.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using GLTF.Schema;
 using UnityEditor;
+using UnityEngine;
 
 #if UNITY_EDITOR
 using UnityEditor.AssetImporters;
@@ -14,7 +15,7 @@ namespace UnityGLTF.Plugins
 		public readonly AssetImportContext AssetContext;
 		public string FilePath => AssetContext?.assetPath;
 		public readonly AssetImporter SourceImporter;
-		public float ImportScaleFactor = 1.0f;
+		public Vector3 ImportScaleFactor = Vector3.one;
 #endif
 
 		public readonly List<GLTFImportPluginContext> Plugins;

--- a/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
@@ -520,7 +520,7 @@ namespace UnityGLTF
 #if UNITY_EDITOR
 							// TODO technically this should be postprocessing in the ScriptedImporter instead,
 							// but performance is much better if we do it when constructing the clips
-							var factor = Context?.ImportScaleFactor ?? 1f;
+							var factor = Context?.ImportScaleFactor ?? Vector3.one;
 #endif
 							SetAnimationCurve(clip, relativePath, propertyNames, input, output,
 								samplerCache.Interpolation, typeof(Transform),
@@ -529,7 +529,7 @@ namespace UnityGLTF
 									var position = data.AsFloat3s[frame].ToUnityVector3Convert();
 #if UNITY_EDITOR
 									return new float[]
-										{ position.x * factor, position.y * factor, position.z * factor };
+										{ position.x * factor.x, position.y * factor.y, position.z * factor.z };
 #else
 											  return new float[] { position.x, position.y, position.z };
 #endif

--- a/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -809,10 +809,10 @@ namespace UnityGLTF
 
 		protected virtual void ConstructMeshTargets(MeshPrimitive primitive, int meshIndex, int primitiveIndex)
 		{
-			float scaleFactor = 0f;
+			float3 scaleFactor = 0f;
 			bool hasScale = false;
 #if UNITY_EDITOR
-			hasScale = Context != null && !Mathf.Approximately(Context.ImportScaleFactor, 1f);
+			hasScale = Context != null && (!Mathf.Approximately(Context.ImportScaleFactor.x, 1f) || !Mathf.Approximately(Context.ImportScaleFactor.y, 1f) || !Mathf.Approximately(Context.ImportScaleFactor.z, 1f));
 			scaleFactor = hasScale ? Context.ImportScaleFactor : 1f;
 #endif	
 			


### PR DESCRIPTION
This is a small change that is useful for our workflow (and likely others), to allow the GLTF import Scale Factor to be axis independent.

This allows an easy way to fix any assumptions that the modelling application might have made about co-ordinate space in a non-destructive way on import without changing any of the core logic around how GLTF calculates the co-ordinate space (Y-Up, Z-Forward). It also allows for much rarer scenarios where you might want to scale any axis with differing scale factors. 

Existing behaviour is maintained fully, with new independent scaling behaviour being exposed in the UI as a simple check box:

<img width="628" height="170" alt="image" src="https://github.com/user-attachments/assets/814199ea-48f8-4cf9-98a3-53df9001b61e" />