### PR TITLE
Fix: Add missing using UnityEngine directive

### DIFF
--- a/Runtime/Scripts/Interactivity/Export/CleanUp/TickNodeDeduplicationCleanUp.cs
+++ b/Runtime/Scripts/Interactivity/Export/CleanUp/TickNodeDeduplicationCleanUp.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using UnityGLTF.Interactivity.Schema;
+using UnityEngine;
 
 namespace UnityGLTF.Interactivity.Export
 {


### PR DESCRIPTION
Fixes CS0246 compilation error in Unity 2022.3, Unity 2021.3 Added missing 'using UnityEngine;' for RuntimeInitializeOnLoadMethodAttribute