### PR TITLE
Unity 6.6: changes we used to get UnityGLTF working in a consumer project

### DIFF
--- a/Editor/Scripts/GLTFExportMenu.cs
+++ b/Editor/Scripts/GLTFExportMenu.cs
@@ -622,14 +622,14 @@ namespace UnityGLTF
 
 			var importAction = ScriptableObject.CreateInstance<AdjustImporterAction>();
 			importAction.fileContent = content;
-			ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, importAction, filename, null, (string) null);
+			ProjectWindowUtil.StartNameEditingIfProjectWindowExists(EntityId.None, importAction, filename, null, (string) null);
 		}
 
 		// Based on DoCreateAssetWithContent.cs
-		private class AdjustImporterAction : EndNameEditAction
+		private class AdjustImporterAction : AssetCreationEndAction
 		{
 			public string fileContent;
-			public override void Action(int instanceId, string pathName, string resourceFile)
+			public override void Action(EntityId entityId, string pathName, string resourceFile)
 			{
 				var templateContent = SetLineEndings(fileContent, EditorSettings.lineEndingsForNewScripts);
 				File.WriteAllText(Path.GetFullPath(pathName), templateContent);

--- a/Editor/Scripts/GLTFImporterInspector.cs
+++ b/Editor/Scripts/GLTFImporterInspector.cs
@@ -150,8 +150,8 @@ namespace UnityGLTF
 		private const string TextureRemappingKey = nameof(GLTFImporterInspector) + "_TextureRemapping";
 		private bool EnableTextureRemapping
 		{
-			get => SessionState.GetBool(TextureRemappingKey + target.GetInstanceID(), false);
-			set => SessionState.SetBool(TextureRemappingKey + target.GetInstanceID(), value);
+			get => SessionState.GetBool(TextureRemappingKey + target.GetEntityId().GetHashCode(), false);
+			set => SessionState.SetBool(TextureRemappingKey + target.GetEntityId().GetHashCode(), value);
 		}
 		private static readonly GUIContent RemapTexturesToggleContent = new GUIContent("Experimental", "(experimental) Remap textures inside the glTF to textures that are already in your project.");
 

--- a/Editor/Scripts/Interactivity/VisualScriptingExport/UnitExporters/Flow/SelectOnFlowUnitExporter.cs
+++ b/Editor/Scripts/Interactivity/VisualScriptingExport/UnitExporters/Flow/SelectOnFlowUnitExporter.cs
@@ -34,7 +34,7 @@ namespace UnityGLTF.Interactivity.VisualScripting.Export
             int typeIndex = 0;
             
             // using VariableKind.Scene, because we already generated a unique name for the variable
-            var varIndex = unitExporter.vsExportContext.AddVariableWithIdIfNeeded($"SelectOnFlowValue_{GUID.Generate().ToString()}", null, VariableKind.Scene, typeIndex);
+            var varIndex = unitExporter.vsExportContext.AddVariableWithIdIfNeeded($"SelectOnFlowValue_{Guid.NewGuid():N}", null, VariableKind.Scene, typeIndex);
 
             var getVar = VariablesHelpers.GetVariable(unitExporter, varIndex, out var getVarValue);
             getVarValue.MapToPort(unit.selection);

--- a/Editor/Scripts/ShaderGraph/MaterialLibraryEditor.cs
+++ b/Editor/Scripts/ShaderGraph/MaterialLibraryEditor.cs
@@ -166,10 +166,10 @@ namespace UnityGLTF
                 img.image = preview;
                 if (!preview)
                 {
-                    var instanceId = mat.GetInstanceID();
+                    var entityId = mat.GetEntityId();
                     void WaitForPreview()
                     {
-                        if (AssetPreview.IsLoadingAssetPreview(instanceId)) return;
+                        if (AssetPreview.IsLoadingAssetPreview(entityId)) return;
                         EditorApplication.update -= WaitForPreview;
                         img.image = AssetPreview.GetAssetPreview(mat);
                     }

--- a/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/Runtime/Scripts/GLTFSceneExporter.cs
@@ -153,6 +153,16 @@ namespace UnityGLTF
 		private List<GLTFExportPluginContext> _plugins = new List<GLTFExportPluginContext>();
 
 		public IReadOnlyList<GLTFExportPluginContext> Plugins => _plugins;
+
+		private static int GetExportedObjectKey(UnityEngine.Object obj)
+		{
+			return obj ? obj.GetEntityId().GetHashCode() : 0;
+		}
+
+		private static string GetObjectIdLabel(UnityEngine.Object obj)
+		{
+			return obj ? obj.GetEntityId().ToString() : "None";
+		}
 		
 		public struct TextureMapType
 		{
@@ -1086,7 +1096,8 @@ namespace UnityGLTF
 
 		private NodeId ExportNode(Transform nodeTransform)
 		{
-			if (_exportedTransforms.TryGetValue(nodeTransform.GetInstanceID(), out var existingNodeId))
+			int transformKey = GetExportedObjectKey(nodeTransform);
+			if (_exportedTransforms.TryGetValue(transformKey, out var existingNodeId))
 				return new NodeId() { Id = existingNodeId, Root = _root };
 
 			foreach (var plugin in _plugins)
@@ -1158,7 +1169,7 @@ namespace UnityGLTF
 			};
 
 			// Register nodes for animation parsing (could be disabled if animation is disabled)
-			_exportedTransforms.Add(nodeTransform.GetInstanceID(), _root.Nodes.Count);
+			_exportedTransforms.Add(transformKey, _root.Nodes.Count);
 
 			_root.Nodes.Add(node);
 
@@ -1387,7 +1398,7 @@ namespace UnityGLTF
 			if (materialObj == DefaultMaterial)
 				materialKey = 0;
 			else if (materialObj)
-				materialKey = materialObj.GetInstanceID();
+				materialKey = GetExportedObjectKey(materialObj);
 
 			if (_exportedMaterials.TryGetValue(materialKey, out var id))
 			{

--- a/Runtime/Scripts/RenderPipelines/RoughRefractionFeature.cs
+++ b/Runtime/Scripts/RenderPipelines/RoughRefractionFeature.cs
@@ -24,6 +24,7 @@ namespace UnityGLTF
 #if !UNITY_6000_2_OR_NEWER
 		private Downsampling downsampling = Downsampling.None;
 #endif
+#if !UNITY_6000_4_OR_NEWER
 	    class CustomRenderPass : CopyColorPass
 	    {
 	        public Downsampling m_DownsamplingMethod;
@@ -129,8 +130,11 @@ namespace UnityGLTF
 #endif
 	        }
 	    }
+#endif
 
+#if !UNITY_6000_4_OR_NEWER
 	    private CustomRenderPass m_RoughRefractionPassNonRG;
+#endif
 #if UNITY_2023_3_OR_NEWER
 	    private bool usingRenderGraph = false;
 #endif
@@ -143,11 +147,16 @@ namespace UnityGLTF
 	    public override void Create()
 	    {
 #if UNITY_2023_3_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
+		    usingRenderGraph = true;
+#else
 		    var renderGraphSettings = GraphicsSettings.GetRenderPipelineSettings<RenderGraphSettings>();
 		    usingRenderGraph = !renderGraphSettings.enableRenderCompatibilityMode;
+#endif
 		    if (!usingRenderGraph)
 		    {
 #endif
+#if !UNITY_6000_4_OR_NEWER
 #if UNITY_2022_3_OR_NEWER
 			    if (m_RoughRefractionPassNonRG == null)
 			    {
@@ -155,6 +164,7 @@ namespace UnityGLTF
 			    }
 #else
 				m_OpaqueColor.Init(CAMERA_OPAQUE_TEXTURENAME);
+#endif
 #endif
 
 #if UNITY_2023_3_OR_NEWER
@@ -178,10 +188,12 @@ namespace UnityGLTF
 			    return;
 		    
 #if UNITY_2022_3_OR_NEWER
+#if !UNITY_6000_4_OR_NEWER
 		    if (m_RoughRefractionPassNonRG != null)
 		    {
 				renderer.EnqueuePass(m_RoughRefractionPassNonRG);
 		    }
+#endif
 #if UNITY_2023_3_OR_NEWER
 		    else
 		    if (usingRenderGraph && m_RoughRefractionPassRG != null)
@@ -206,7 +218,7 @@ namespace UnityGLTF
 #endif
 	    }
 	    
-#if UNITY_2022_3_OR_NEWER && !UNITY_6000_2_OR_NEWER
+#if UNITY_2022_3_OR_NEWER && !UNITY_6000_2_OR_NEWER && !UNITY_6000_4_OR_NEWER
 		public override void SetupRenderPasses(ScriptableRenderer renderer, in RenderingData renderingData)
 		{
 #pragma warning disable 618

--- a/Runtime/Scripts/SceneExporter/ExporterAnimation.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterAnimation.cs
@@ -704,9 +704,9 @@ namespace UnityGLTF
 			if (obj == null) return "null";
 
 			if (obj is Component tr)
-				return $"{tr.name} (InstanceID: {tr.GetInstanceID()}, Type: {tr.GetType()})";
+				return $"{tr.name} (EntityId: {GetObjectIdLabel(tr)}, Type: {tr.GetType()})";
 			if (obj is GameObject go)
-				return $"{go.name} (InstanceID: {go.GetInstanceID()})";
+				return $"{go.name} (EntityId: {GetObjectIdLabel(go)})";
 
 			return obj.ToString();
 		}
@@ -1589,25 +1589,25 @@ namespace UnityGLTF
 
 		public int GetTransformIndex(Transform transform)
 		{
-			if (transform && _exportedTransforms.TryGetValue(transform.GetInstanceID(), out var index)) return index;
+			if (transform && _exportedTransforms.TryGetValue(GetExportedObjectKey(transform), out var index)) return index;
 			return -1;
 		}
 
 		public int GetMaterialIndex(Material mat)
 		{
-			if (mat && _exportedMaterials.TryGetValue(mat.GetInstanceID(), out var index)) return index;
+			if (mat && _exportedMaterials.TryGetValue(GetExportedObjectKey(mat), out var index)) return index;
 			return -1;
 		}
 
 		public int GetLightIndex(Light light)
 		{
-			if (light && _exportedLights.TryGetValue(light.GetInstanceID(), out var index)) return index;
+			if (light && _exportedLights.TryGetValue(GetExportedObjectKey(light), out var index)) return index;
 			return -1;
 		}
 
 		public int GetCameraIndex(Camera cam)
 		{
-			if (cam && _exportedCameras.TryGetValue(cam.GetInstanceID(), out var index)) return index;
+			if (cam && _exportedCameras.TryGetValue(GetExportedObjectKey(cam), out var index)) return index;
 			return -1;
 		}
 

--- a/Runtime/Scripts/SceneExporter/ExporterAnimationPointer.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterAnimationPointer.cs
@@ -86,17 +86,17 @@ namespace UnityGLTF
 				{
 					if (go.CompareTag("EditorOnly"))
 					{
-						Debug.LogWarning(null, $"Animation for {animatedObject.name} ({animatedObject.GetType()}) has not been exported as the object itself is not exported (EditorOnly). Remove the EditorOnly tag when you want to export the GameObject. (InstanceID: {animatedObject.GetInstanceID()})", animatedObject);
+						Debug.LogWarning(null, $"Animation for {animatedObject.name} ({animatedObject.GetType()}) has not been exported as the object itself is not exported (EditorOnly). Remove the EditorOnly tag when you want to export the GameObject. (EntityId: {GetObjectIdLabel(animatedObject)})", animatedObject);
 						return;
 					}
 					if (!go.activeSelf || !go.activeInHierarchy)
 					{
-						Debug.LogWarning(null, $"Animation for {animatedObject.name} ({animatedObject.GetType()}) has not been exported as the object itself is not exported. Enable the GameObject when you want to export it or enable 'Export disabled Game Objects' in the settings. (InstanceID: {animatedObject.GetInstanceID()})", animatedObject);
+						Debug.LogWarning(null, $"Animation for {animatedObject.name} ({animatedObject.GetType()}) has not been exported as the object itself is not exported. Enable the GameObject when you want to export it or enable 'Export disabled Game Objects' in the settings. (EntityId: {GetObjectIdLabel(animatedObject)})", animatedObject);
 						return;
 					}
 					
 				}
-				Debug.LogWarning(null, $"Animation for {animatedObject.name} ({animatedObject.GetType()}) has not been exported as the object itself is not exported (disabled/EditorOnly). (InstanceID: {animatedObject.GetInstanceID()})", animatedObject);
+				Debug.LogWarning(null, $"Animation for {animatedObject.name} ({animatedObject.GetType()}) has not been exported as the object itself is not exported (disabled/EditorOnly). (EntityId: {GetObjectIdLabel(animatedObject)})", animatedObject);
 				return;
 			}
 

--- a/Runtime/Scripts/SceneExporter/ExporterCameras.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterCameras.cs
@@ -67,7 +67,7 @@ namespace UnityGLTF
 			};
 
 			// Register nodes for animation parsing (could be disabled if animation is disabled)
-			_exportedCameras.Add(unityCamera.GetInstanceID(), _root.Cameras.Count);
+			_exportedCameras.Add(GetExportedObjectKey(unityCamera), _root.Cameras.Count);
 			_root.Cameras.Add(camera);
 
 			return id;

--- a/Runtime/Scripts/SceneExporter/ExporterLights.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterLights.cs
@@ -86,7 +86,7 @@ namespace UnityGLTF
             };
 
             // Register nodes for animation parsing (could be disabled if animation is disabled)
-            _exportedLights.Add(unityLight.GetInstanceID(), _root.Lights.Count);
+            _exportedLights.Add(GetExportedObjectKey(unityLight), _root.Lights.Count);
 
             //list of lightids should be in extensions object
             _root.Lights.Add(light);

--- a/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -387,7 +387,7 @@ namespace UnityGLTF
 
         private MaterialId CreateAndAddMaterialId(Material materialObj, GLTFMaterial material)
         {
-	        var key = materialObj ? materialObj.GetInstanceID() : 0;
+	        var key = materialObj ? GetExportedObjectKey(materialObj) : 0;
 	        if(!_exportedMaterials.ContainsKey(key))
 				_exportedMaterials.Add(key, _root.Materials.Count);
 

--- a/Runtime/Scripts/SceneExporter/ExporterSkinning.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterSkinning.cs
@@ -44,7 +44,7 @@ namespace UnityGLTF
 					Debug.LogWarning("Skin has null bone at index " + i + ": " + skin, skin);
 					continue;
 				}
-				var nodeId = skin.bones[i].GetInstanceID();
+				var nodeId = GetExportedObjectKey(skin.bones[i]);
 				if (!_exportedTransforms.ContainsKey(nodeId))
 				{
 					allBoneTransformNodesHaveBeenExported = false;
@@ -66,7 +66,7 @@ namespace UnityGLTF
 					continue;
 				}
 
-				var nodeId = skin.bones[i].GetInstanceID();
+				var nodeId = GetExportedObjectKey(skin.bones[i]);
 
 				gltfSkin.Joints.Add(
 					new NodeId
@@ -130,7 +130,7 @@ namespace UnityGLTF
 				}
 			}
 
-			_root.Nodes[_exportedTransforms[transform.GetInstanceID()]].Skin = new SkinId() { Id = _root.Skins.Count, Root = _root };
+			_root.Nodes[_exportedTransforms[GetExportedObjectKey(transform)]].Skin = new SkinId() { Id = _root.Skins.Count, Root = _root };
 			_root.Skins.Add(gltfSkin);
 
 			exportSkinFromNodeMarker.End();

--- a/UNITY_6_6_NOTES.md
+++ b/UNITY_6_6_NOTES.md
@@ -1,0 +1,32 @@
+# Unity 6.6 viability notes
+
+This branch is not presented as a finished Unity 6.6 support release. It is a record of the changes we used in a consumer project to get UnityGLTF working again on Unity 6.6 alpha.
+
+## What this fixes
+
+- Replaces exporter-side `GetInstanceID()` usage that turns into hard failures on Unity 6.6 with `GetEntityId()`-based keys and labels.
+- Updates editor asset creation code to the newer `AssetCreationEndAction` and `EntityId` APIs.
+- Updates editor state and preview tracking code to use entity ids where Unity 6.6 no longer accepts instance ids.
+- Forces the rough refraction renderer feature onto the RenderGraph-compatible path on newer Unity 6 releases where the older compatibility path is no longer viable.
+- Replaces one Visual Scripting exporter `GUID.Generate()` call with `Guid.NewGuid()` to avoid an editor-side API mismatch we hit during the migration.
+
+## Where this was exercised
+
+These changes were taken from a Unity 6.6 alpha migration branch in a real game project that embeds UnityGLTF as a package dependency.
+
+In that consumer project, this patch set was enough to:
+
+- restore clean compilation under Unity 6.6 alpha,
+- bring back editor import of existing `.glb` assets that had stopped working after the engine upgrade,
+- keep the project's current PlayMode suite green, and
+- produce a successful player build again once the surrounding project-side issues were handled.
+
+## Scope and limits
+
+- This branch is intentionally narrow. It captures the concrete changes we needed for Unity 6.6 viability, not a broad compatibility audit across all UnityGLTF features.
+- The validation evidence comes from the consumer project integration described above. We did not run a separate full UnityGLTF package test pass in this forked workspace.
+- We left out unrelated package metadata and Unity-authored serialization noise from the consumer branch so the patch stays focused on the actual compatibility edits.
+
+## Suggested PR framing
+
+If this goes upstream, the safest framing is: here are the changes we used to get UnityGLTF working for Unity 6.6 in a real project, with the expectation that Khronos can review, tighten, or extend them as needed.


### PR DESCRIPTION
# Unity 6.6 viability notes

This branch is not presented as a finished Unity 6.6 support release. It is a record of the changes we used in a consumer project to get UnityGLTF working again on Unity 6.6 alpha.

## What this fixes

- Replaces exporter-side `GetInstanceID()` usage that turns into hard failures on Unity 6.6 with `GetEntityId()`-based keys and labels.
- Updates editor asset creation code to the newer `AssetCreationEndAction` and `EntityId` APIs.
- Updates editor state and preview tracking code to use entity ids where Unity 6.6 no longer accepts instance ids.
- Forces the rough refraction renderer feature onto the RenderGraph-compatible path on newer Unity 6 releases where the older compatibility path is no longer viable.
- Replaces one Visual Scripting exporter `GUID.Generate()` call with `Guid.NewGuid()` to avoid an editor-side API mismatch we hit during the migration.

## Scope and limits

- This branch is intentionally narrow. It captures the concrete changes we needed for Unity 6.6 viability, not a broad compatibility audit across all UnityGLTF features.
- The validation evidence comes from the consumer project integration described above. We did not run a separate full UnityGLTF package test pass in this forked workspace.
- We left out unrelated package metadata and Unity-authored serialization noise from the consumer branch so the patch stays focused on the actual compatibility edits.
